### PR TITLE
Remove duplicate IConfigurable

### DIFF
--- a/ckanext/knowledgehub/plugin.py
+++ b/ckanext/knowledgehub/plugin.py
@@ -13,7 +13,6 @@ class KnowledgehubPlugin(plugins.SingletonPlugin, DefaultDatasetForm):
     plugins.implements(plugins.IBlueprint)
     plugins.implements(plugins.IActions)
     plugins.implements(plugins.IAuthFunctions)
-    plugins.implements(plugins.IConfigurable)
     plugins.implements(plugins.ITemplateHelpers)
     plugins.implements(plugins.IDatasetForm)
     plugins.implements(plugins.IPackageController, inherit=True)


### PR DESCRIPTION
This PR removes duplicate definition of `IConfigurable` in `KnowledgehubPlugin`.