### PR TITLE
Setup database table for dashboards

### DIFF
--- a/ckanext/knowledgehub/cli/db.py
+++ b/ckanext/knowledgehub/cli/db.py
@@ -7,6 +7,7 @@ from ckanext.knowledgehub.cli import error_shout
 from ckanext.knowledgehub.model.theme import theme_db_setup
 from ckanext.knowledgehub.model.research_question import setup as rq_db_setup
 from ckanext.knowledgehub.model.sub_theme import setup as sub_theme_db_setup
+from ckanext.knowledgehub.model.dashboard import setup as dashboard_db_setup
 
 log = logging.getLogger(__name__)
 
@@ -24,6 +25,7 @@ def init():
         theme_db_setup()
         sub_theme_db_setup()
         rq_db_setup()
+        dashboard_db_setup()
     except Exception as e:
         error_shout(e)
     else:

--- a/ckanext/knowledgehub/model/__init__.py
+++ b/ckanext/knowledgehub/model/__init__.py
@@ -1,10 +1,12 @@
 from ckanext.knowledgehub.model.theme import Theme
 from ckanext.knowledgehub.model.sub_theme import SubThemes
 from ckanext.knowledgehub.model.research_question import ResearchQuestion
+from ckanext.knowledgehub.model.dashboard import Dashboard
 
 
 __all__ = [
     'Theme',
     'SubThemes',
-    'ResearchQuestion'
+    'ResearchQuestion',
+    'Dashboard'
 ]

--- a/ckanext/knowledgehub/model/dashboard.py
+++ b/ckanext/knowledgehub/model/dashboard.py
@@ -1,0 +1,46 @@
+import datetime
+
+from sqlalchemy import (
+    types,
+    Column,
+    Table,
+)
+
+from ckan.model.meta import (
+    metadata,
+    mapper,
+    engine
+)
+from ckan.model.types import make_uuid
+from ckan.model.domain_object import DomainObject
+
+__all__ = ['Dashboard', 'dashboard_table']
+
+dashboard_table = Table(
+    'ckanext_knowledgehub_dashboard', metadata,
+    Column('id', types.UnicodeText,
+           primary_key=True, default=make_uuid),
+    Column('name', types.UnicodeText,
+           nullable=False, unique=True),
+    Column('title', types.UnicodeText, nullable=False),
+    Column('description', types.UnicodeText, nullable=False),
+    Column('type', types.UnicodeText, nullable=False),
+    Column('source', types.UnicodeText),
+    Column('indicators', types.JSON),
+    Column('created_at', types.DateTime,
+           default=datetime.datetime.utcnow),
+    Column('modified_at', types.DateTime,
+           default=datetime.datetime.utcnow),
+)
+
+
+class Dashboard(DomainObject):
+    # TODO(Aleksandar): Implement actions
+    pass
+
+
+mapper(Dashboard, dashboard_table)
+
+
+def setup():
+    metadata.create_all(engine)


### PR DESCRIPTION
This PR shall setup a database table for dashboards. The `indicators` column represents an array of resource view ids. 

The implementation of the CRUD operations shall be part of a new PR.

_Make sure to run the CLI command `knowledgehub -c /etc/ckan/default/production.ini db init` to initialize the database table._