### PR TITLE
Implement Index page for dashboards

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,10 @@ These are the optional configuration settings used by the extension::
     # (optional, default: 10).
     ckanext.knowledgehub.sub_themes_per_page = 20
 
+    # The number of dashboards shown per page
+    # (optional, default: 10).
+    ckanext.knowledgehub.dashboards_per_page = 20
+
 ------------------------
 Development Installation
 ------------------------

--- a/ckanext/knowledgehub/logic/auth/get.py
+++ b/ckanext/knowledgehub/logic/auth/get.py
@@ -9,3 +9,8 @@ def research_question_show(context, data_dict):
 @toolkit.auth_allow_anonymous_access
 def research_question_list(context, data_dict):
     return {'success': True}
+
+
+@toolkit.auth_allow_anonymous_access
+def dashboard_list(context, data_dict):
+    return {'success': True}

--- a/ckanext/knowledgehub/templates/dashboard/index.html
+++ b/ckanext/knowledgehub/templates/dashboard/index.html
@@ -1,0 +1,42 @@
+{% extends "page.html" %}
+
+{% block subtitle %}{{ _('Dashboards') }}{% endblock %}
+
+{% block breadcrumb_content %}
+  <li class="active">{{ h.nav_link(_('Dashboards'), named_route='dashboards.index') }}</li>
+{% endblock %}
+
+{% block page_header %}{% endblock %}
+
+{% block page_primary_action %}
+  {% if h.check_access('dashboard_create') %}
+    {% link_for _('Add Dashboard'), named_route='dashboards.new', class_='btn btn-primary', icon='plus-square' %}
+  {% endif %}
+{% endblock %}
+
+{% block primary_content_inner %}
+  <h1 class="hide-heading">{% block page_heading %}{{ _('Dashboards') }}{% endblock %}</h1>
+  {% block dashboards_search_form %}
+    {% snippet 'snippets/search_form.html', form_id='dashboard-search-form', type='dashboard', query=q, sorting_selected=sort_by_selected, count=page.item_count, placeholder=_('Search dashboards...'), sorting = [(_('Name Ascending'), 'name asc'), (_('Name Descending'), 'name desc')] %}
+  {% endblock %}
+  {% block dashboards_list %}
+    {% if page.items %}
+        {% snippet "dashboard/snippets/dashboard_list.html", dashboards=page.items %}
+    {% else %}
+      <p class="empty">
+        {{ _('There are currently no dashboards for this site') }}.
+        {% if h.check_access('dashboard_create') %}
+          {% link_for _('How about creating one?'), named_route='dashboards.new' %}</a>.
+        {% endif %}
+      </p>
+    {% endif %}
+  {% endblock %}
+
+  {% block page_pagination %}
+   {{ page.pager(q=q or '', sort=sort_by_selected or '') }}
+  {% endblock %}
+{% endblock %}
+
+{% block secondary_content %}
+  {% snippet "dashboard/snippets/helper.html" %}
+{% endblock %}

--- a/ckanext/knowledgehub/templates/dashboard/snippets/dashboard_item.html
+++ b/ckanext/knowledgehub/templates/dashboard/snippets/dashboard_item.html
@@ -1,0 +1,22 @@
+{% set truncate = truncate or 180 %} {% set truncate_title = truncate_title or
+80 %} {% set title = dashboard.title or dashboard.name %} {% set notes =
+h.markdown_extract(dashboard.description, extract_length=truncate) %} {% block
+dashboard_item %}
+<li class="component-item">
+  {% block content %}
+  <div class="component-content">
+    {% block heading %}
+    <h3 class="component-heading">
+      {% block heading_title %}
+      {{ h.link_to(h.truncate(title, truncate_title), h.url_for('dashboards.read', name=dashboard.name)) }}
+      {% endblock %}
+    </h3>
+    {% endblock %} {% block notes %} {% if notes %}
+    <div>{{ notes | urlize }}</div>
+    {% else %}
+    <p class="empty">{{ _('This dashboard has no description') }}</p>
+    {% endif %} {% endblock %}
+  </div>
+  {% endblock %}
+</li>
+{% endblock %}

--- a/ckanext/knowledgehub/templates/dashboard/snippets/dashboard_list.html
+++ b/ckanext/knowledgehub/templates/dashboard/snippets/dashboard_list.html
@@ -1,0 +1,9 @@
+{# Display a grid of dashboard items. dashboards - A list of dashboards.
+Example: {% snippet "dashboard/snippets/dashboard_list.html" %} #} {% block
+dashboard_list %} {% if dashboards %}
+<ul class="component-list list-unstyled">
+  {% block dashboard_list_inner %} {% for dashboard in dashboards %} {% snippet
+  "dashboard/snippets/dashboard_item.html", dashboard=dashboard,
+  position=loop.index %} {% endfor %} {% endblock %}
+</ul>
+{% endif %} {% endblock %}

--- a/ckanext/knowledgehub/templates/dashboard/snippets/helper.html
+++ b/ckanext/knowledgehub/templates/dashboard/snippets/helper.html
@@ -1,0 +1,11 @@
+<div class="module module-narrow module-shallow">
+  <h2 class="module-heading">
+    <i class="fa fa-info-circle"></i>
+    {{ _('What are Dashboards?') }}
+  </h2>
+  <div class="module-content">
+    <p>
+      {% trans %} Dashboards are ... {% endtrans %}
+    </p>
+  </div>
+</div>

--- a/ckanext/knowledgehub/templates/header.html
+++ b/ckanext/knowledgehub/templates/header.html
@@ -57,7 +57,7 @@ search  </div>
         <li><a href="{% url_for 'theme.index' %}">{{ _('Themes') }}</a></li>
         <li><a href="{% url_for 'sub_theme.search' %}">{{ _('Sub-Themes') }}</a></li>
         <li><a href="{% url_for 'research_question.search' %}">{{ _('Research Questions') }}</a></li>
-        <li><a href="#">Dashboards</a></li>
+        <li><a href="{% url_for 'dashboards.index' %}">Dashboards</a></li>
       </ul>
     </div>
   </div>

--- a/ckanext/knowledgehub/views/dashboard.py
+++ b/ckanext/knowledgehub/views/dashboard.py
@@ -1,0 +1,90 @@
+# encoding: utf-8
+import logging
+
+from flask import Blueprint
+from flask.views import MethodView
+import ckan.lib.base as base
+import ckan.lib.helpers as h
+import ckan.lib.navl.dictization_functions as dict_fns
+import ckan.logic as logic
+import ckan.model as model
+from ckan.common import _, config, g, request
+
+NotFound = logic.NotFound
+NotAuthorized = logic.NotAuthorized
+ValidationError = logic.ValidationError
+check_access = logic.check_access
+get_action = logic.get_action
+tuplize_dict = logic.tuplize_dict
+clean_dict = logic.clean_dict
+parse_params = logic.parse_params
+flatten_to_string_key = logic.flatten_to_string_key
+
+log = logging.getLogger(__name__)
+
+
+dashboard = Blueprint(
+    u'dashboards',
+    __name__,
+    url_prefix=u'/dashboards'
+)
+
+
+def index():
+    u''' dashboards index view function '''
+
+    extra_vars = {}
+
+    context = {
+        u'model': model,
+        u'session': model.Session,
+        u'user': g.user,
+        u'auth_user_obj': g.userobj
+    }
+
+    try:
+        check_access(u'dashboard_list', context)
+    except NotAuthorized:
+        base.abort(403, _(u'Not authorized to see this page'))
+
+    page = h.get_page_number(request.params) or 1
+    items_per_page = int(config.get(u'ckanext.'
+                                    u'knowledgehub.dashboards_per_page',
+                                    10))
+    q = request.params.get(u'q', u'')
+    sort_by = request.params.get(u'sort', u'name asc')
+
+    data_dict_global_results = {
+        u'q': q,
+        u'sort': sort_by
+    }
+
+    data_dict_page_results = {
+        u'q': q,
+        u'sort': sort_by,
+        u'limit': items_per_page,
+        u'offset': items_per_page * (page - 1)
+    }
+
+    extra_vars["q"] = q
+    extra_vars["sort_by_selected"] = sort_by
+
+    global_results = get_action(u'dashboard_list')(context,
+                                                   data_dict_global_results)
+
+    page_results = get_action(u'dashboard_list')(context,
+                                                 data_dict_page_results)
+
+    extra_vars["page"] = h.Page(
+        collection=global_results['data'],
+        page=page,
+        url=h.pager_url,
+        items_per_page=items_per_page)
+
+    extra_vars['page'].items = page_results['data']
+
+    return base.render(u'dashboard/index.html',
+                       extra_vars=extra_vars)
+
+
+dashboard.add_url_rule(u'/', view_func=index, strict_slashes=False)


### PR DESCRIPTION
This PR implements the Index page for listing dashboards (`/dashboards`). Dashboards can be searched and ordered.

Adding a dashboard and viewing a single dashboard will be implemented in new PRs.