### PR TITLE
Add page for creating a dashboard

### DIFF
--- a/ckanext/knowledgehub/fanstatic/javascript/modules/dashboard_type_select.js
+++ b/ckanext/knowledgehub/fanstatic/javascript/modules/dashboard_type_select.js
@@ -1,0 +1,25 @@
+/*
+
+This module handles selecting dashboard type. If it's `internal` it displays
+UI for inserting an indicator, if it's `external` it displays an input to
+enter the source.
+
+*/
+ckan.module('knowledgehub-dashboard-type-select', function ($) {
+    return {
+        initialize: function () {
+            this.sourceField = $('#dashboard-edit-form').find('#field-source')
+            this.el.on('change', this.selectType.bind(this));
+        },
+        selectType() {
+            var typeValue = this.el.val();
+            if (!typeValue) {
+                this.sourceField.parent().parent().addClass('hidden');
+            } else if (typeValue === 'internal') {
+                this.sourceField.parent().parent().addClass('hidden');
+            } else if (typeValue === 'external') {
+                this.sourceField.parent().parent().removeClass('hidden');
+            }
+        }
+    }
+});

--- a/ckanext/knowledgehub/logic/action/create.py
+++ b/ckanext/knowledgehub/logic/action/create.py
@@ -288,6 +288,7 @@ def dashboard_create(context, data_dict):
         :param title
         :param description
         :param type
+        :param source
         :param indicators
     '''
     check_access('dashboard_create', context)
@@ -302,7 +303,7 @@ def dashboard_create(context, data_dict):
 
     dashboard = Dashboard()
 
-    items = ['name', 'title', 'description', 'type', 'indicators']
+    items = ['name', 'title', 'description', 'type']
 
     for item in items:
         setattr(dashboard, item, data.get(item))
@@ -311,9 +312,13 @@ def dashboard_create(context, data_dict):
     dashboard.modified_at = datetime.datetime.utcnow()
 
     source = data.get('source')
+    indicators = data.get('indicators')
 
     if source is not None:
         dashboard.source = source
+
+    if indicators is not None:
+        dashboard.indicators = indicators
 
     dashboard.save()
 

--- a/ckanext/knowledgehub/logic/schema.py
+++ b/ckanext/knowledgehub/logic/schema.py
@@ -87,5 +87,5 @@ def dashboard_schema():
         'created_at': [ignore_missing, isodate],
         'modified_at': [ignore_missing, isodate],
         'source': [ignore_missing, unicode],
-        'indicators': [not_empty, convert_to_json_if_string, unicode],
+        'indicators': [ignore_missing, convert_to_json_if_string, unicode],
     }

--- a/ckanext/knowledgehub/model/dashboard.py
+++ b/ckanext/knowledgehub/model/dashboard.py
@@ -30,7 +30,7 @@ dashboard_table = Table(
     Column('description', types.UnicodeText, nullable=False),
     Column('type', types.UnicodeText, nullable=False),
     Column('source', types.UnicodeText),
-    Column('indicators', types.UnicodeText, nullable=False),
+    Column('indicators', types.UnicodeText),
     Column('created_at', types.DateTime,
            default=datetime.datetime.utcnow),
     Column('modified_at', types.DateTime,

--- a/ckanext/knowledgehub/templates/dashboard/base_form_page.html
+++ b/ckanext/knowledgehub/templates/dashboard/base_form_page.html
@@ -1,0 +1,22 @@
+{% extends "page.html" %}
+
+{% block subtitle %}{{ _('Create a Dashboard') }}{% endblock %}
+
+{% block breadcrumb_content %}
+  <li>{{ h.nav_link(_('Dashboards'), named_route='dashboard.index') }}</li>
+  <li class="active">{{ h.nav_link(_('Create a Dashboard'), named_route='dashboard.new') }}</li>
+{% endblock %}
+
+{% block page_header %}
+{% endblock %}
+
+{% block primary_content_inner %}
+  <h1 class="{% block page_heading_class %}page-heading{% endblock %}">
+    {% block page_heading %}{{ _('Create a Dashboard') }}{% endblock %}
+  </h1>
+  {% snippet 'dashboard/new_dashboard_form.html', data=data, errors=errors, error_summary=error_summary %}
+{% endblock %}
+
+{% block secondary_content %}
+  {% snippet "dashboard/snippets/helper.html" %}
+{% endblock %}

--- a/ckanext/knowledgehub/templates/dashboard/new_dashboard_form.html
+++ b/ckanext/knowledgehub/templates/dashboard/new_dashboard_form.html
@@ -1,0 +1,8 @@
+{% extends "dashboard/snippets/dashboard_form.html" %}
+
+{% block save_text %}
+  {{ _('Create Dashboard') }}
+{% endblock %}
+
+{% block delete_button %}
+{% endblock %}

--- a/ckanext/knowledgehub/templates/dashboard/snippets/dashboard_form.html
+++ b/ckanext/knowledgehub/templates/dashboard/snippets/dashboard_form.html
@@ -1,0 +1,40 @@
+{% import 'macros/form.html' as form %}
+
+{% resource 'knowledgehub/javascript/modules/dashboard_type_select.js' %}
+
+<form id='dashboard-edit-form' class="dataset-form" method="post" data-module="basic-form">
+  {% block error_summary %}
+    {{ form.errors(error_summary) }}
+  {% endblock %}
+
+  {% block basic_fields %}
+    {% set dashboard_options = [{'text': 'Choose type', 'value': ''}, {'text': 'Internal', 'value': 'internal'}, {'text': 'External', 'value': 'external'}] %}
+    {% set attrs = {'data-module': 'slug-preview-target', 'class': 'form-control'} %}
+    {{ form.input('title', label=_('Title'), id='field-name', placeholder=_('My Dashboard'), value=data.title, error=errors.title, classes=['control-full'], attrs=attrs, is_required=true) }}
+
+    {%- set prefix = h.url_for('dashboard.read', name='') -%}
+    {%- set domain = h.url_for('dashboard.read', name='', qualified=true) -%}
+    {% set domain = domain|replace("http://", "")|replace("https://", "") %}
+    {% set attrs = {'data-module': 'slug-preview-slug', 'class': 'form-control input-sm', 'data-module-prefix': domain, 'data-module-placeholder': '<' + 'name' + '>'} %}
+
+    {{ form.prepend('name', label=_('URL'), prepend=prefix, id='field-url', placeholder=_('my-dashboard'), value=data.name, error=errors.name, attrs=attrs, is_required=true) }}
+
+    {{ form.markdown('description', label=_('Description'), id='field-description', placeholder=_('A little information about this Dashboard...'), value=data.description, error=errors.description, is_required=true) }}
+
+    {% set attrs = {'data-module': 'knowledgehub-dashboard-type-select', 'class': 'form-control'} %}
+    {{ form.select('type', label=_('Type'), options=dashboard_options, error=errors.type, selected='', is_required=true, attrs=attrs) }}
+
+    {{ form.input('source', label=_('Source'), id='field-source', type='url', placeholder=_('Enter PowerBI Dashboard URL'), value=data.source, error=errors.source, classes=['control-full', 'hidden']) }}
+  {% endblock %}
+
+  {{ form.required_message() }}
+
+  <div class="form-actions">
+    {% block delete_button %}
+      {% if h.check_access('dashboard_create')  %}
+        <a class="btn btn-danger pull-left" href="{% url_for 'dashboard.delete', id=data.id %}" data-module="confirm-action" data-module-content="{{ _('Are you sure you want to delete this Dashboard?') }}">{% block delete_button_text %}{{ _('Delete') }}{% endblock %}</a>
+      {% endif %}
+    {% endblock %}
+    <button class="btn btn-primary" name="save" type="submit">{% block save_text %}{{ _('Save Dashboard') }}{% endblock %}</button>
+  </div>
+</form>


### PR DESCRIPTION
This PR adds a page (`/dashboards/new`) for creating a new dashboard. Currently, only external PowerBI dashboards are supported.