### PR TITLE
Implement dashboard creator

### DIFF
--- a/ckanext/knowledgehub/logic/action/create.py
+++ b/ckanext/knowledgehub/logic/action/create.py
@@ -328,6 +328,9 @@ def dashboard_create(context, data_dict):
     if indicators is not None:
         dashboard.indicators = indicators
 
+    user = context.get('user')
+    dashboard.created_by = model.User.by_name(user.decode('utf8')).id
+
     dashboard.save()
 
     session.add(dashboard)

--- a/ckanext/knowledgehub/model/dashboard.py
+++ b/ckanext/knowledgehub/model/dashboard.py
@@ -35,6 +35,7 @@ dashboard_table = Table(
            default=datetime.datetime.utcnow),
     Column('modified_at', types.DateTime,
            default=datetime.datetime.utcnow),
+    Column('created_by', types.UnicodeText, nullable=False),
 )
 
 

--- a/ckanext/knowledgehub/templates/dashboard/snippets/additional_info.html
+++ b/ckanext/knowledgehub/templates/dashboard/snippets/additional_info.html
@@ -9,8 +9,13 @@
     </thead>
     <tbody>
       {% block dashboard_additional_info %}
+        <tr>
+          <th scope="row" class="dashboard-label">{{ _("Created by") }}</th>
+          <td class="dashboard-details">
+              <a href="{{ h.url_for('user.read', id=dashboard.creator_name) }}">{{ dashboard.creator_fullname }}</a>
+          </td>
+        </tr>
         {% if dashboard.source %}
-          <tr>
             <th scope="row" class="dashboard-label">{{ _("Source") }}</th>
             <td class="dashboard-details">{{ dashboard.source }}</td>
           </tr>

--- a/ckanext/knowledgehub/views/dashboard.py
+++ b/ckanext/knowledgehub/views/dashboard.py
@@ -106,6 +106,10 @@ def read(name):
     except NotFound:
         base.abort(404, _(u'Dashboard not found'))
 
+    creator = model.User.get(dashboard_dict.get('created_by'))
+    dashboard_dict['creator_fullname'] = creator.fullname or creator.name
+    dashboard_dict['creator_name'] = creator.name
+
     extra_vars['dashboard'] = dashboard_dict
 
     return base.render(u'dashboard/read.html', extra_vars=extra_vars)


### PR DESCRIPTION
This PR adds a column `created_by` in the db table for dashboards, and displays the creator in the "Additional information" section for each dashboard.

I have already added this column in the database for the staging portal.