### PR TITLE
Store RQs ids in a dataset

### DIFF
--- a/ckanext/knowledgehub/helpers.py
+++ b/ckanext/knowledgehub/helpers.py
@@ -81,7 +81,7 @@ def get_rq_options():
     rq_list = toolkit.get_action('research_question_list')(context, {})
 
     for rq in rq_list.get(u'data', []):
-        opt = {u'text': rq[u'title'], u'value': rq[u'title']}
+        opt = {u'text': rq[u'title'], u'value': rq[u'title'], u'id': rq[u'id']}
         rq_options.append(opt)
     return rq_options
 
@@ -492,3 +492,18 @@ def resource_view_icon(view):
         return 'table'
     else:
         return 'exclamation'
+
+
+def rq_ids_to_titles(rq_ids):
+    rqs = []
+    context = _get_context()
+
+    for rq_id in rq_ids:
+        try:
+            rq = toolkit.get_action(
+                'research_question_show')(context, {'id': rq_id})
+            rqs.append(rq.get('title'))
+        except logic.NotFound:
+            continue
+
+    return rqs

--- a/ckanext/knowledgehub/logic/action/create.py
+++ b/ckanext/knowledgehub/logic/action/create.py
@@ -15,6 +15,7 @@ from ckan import model
 from ckan.logic.action.create import resource_create as ckan_rsc_create
 import ckan.lib.dictization.model_dictize as model_dictize
 import ckan.lib.dictization.model_save as model_save
+from ckan.logic.action.create import package_create as ckan_package_create
 
 from ckanext.knowledgehub.logic import schema as knowledgehub_schema
 from ckanext.knowledgehub.model.theme import Theme
@@ -23,6 +24,7 @@ from ckanext.knowledgehub.model import ResearchQuestion
 from ckanext.knowledgehub.model import Dashboard
 from ckanext.knowledgehub.backend.factory import get_backend
 from ckanext.knowledgehub.lib.writer import WriterService
+from ckanext.knowledgehub import helpers as plugin_helpers
 
 
 log = logging.getLogger(__name__)
@@ -332,3 +334,25 @@ def dashboard_create(context, data_dict):
     session.commit()
 
     return _table_dictize(dashboard, context)
+
+
+def package_create(context, data_dict):
+    research_questions = data_dict.get('research_question')
+    rq_options = plugin_helpers.get_rq_options()
+    rq_ids = []
+
+    if research_questions:
+        if isinstance(research_questions, list):
+            for rq in research_questions:
+                for rq_opt in rq_options:
+                    if rq == rq_opt.get('text'):
+                        rq_ids.append(rq_opt.get('id'))
+                        break
+            data_dict['research_question'] = rq_ids
+        elif isinstance(research_questions, unicode):
+            for rq in rq_options:
+                if rq.get('text') == research_questions:
+                    data_dict['research_question'] = [rq.get('id')]
+                    break
+
+    return ckan_package_create(context, data_dict)

--- a/ckanext/knowledgehub/logic/action/update.py
+++ b/ckanext/knowledgehub/logic/action/update.py
@@ -13,6 +13,7 @@ from ckan import lib
 from ckan.logic.action.update import resource_update as ckan_rsc_update
 import ckan.lib.dictization.model_dictize as model_dictize
 import ckan.lib.dictization.model_save as model_save
+from ckan.logic.action.update import package_update as ckan_package_update
 
 from ckanext.knowledgehub.logic import schema as knowledgehub_schema
 from ckanext.knowledgehub.model.theme import Theme
@@ -21,6 +22,7 @@ from ckanext.knowledgehub.model import ResearchQuestion
 from ckanext.knowledgehub.model import Dashboard
 from ckanext.knowledgehub.backend.factory import get_backend
 from ckanext.knowledgehub.lib.writer import WriterService
+from ckanext.knowledgehub import helpers as plugin_helpers
 
 
 log = logging.getLogger(__name__)
@@ -321,3 +323,25 @@ def dashboard_update(context, data_dict):
     session.commit()
 
     return _table_dictize(dashboard, context)
+
+
+def package_update(context, data_dict):
+    research_questions = data_dict.get('research_question')
+    rq_options = plugin_helpers.get_rq_options()
+    rq_ids = []
+
+    if research_questions:
+        if isinstance(research_questions, list):
+            for rq in research_questions:
+                for rq_opt in rq_options:
+                    if rq == rq_opt.get('text'):
+                        rq_ids.append(rq_opt.get('id'))
+                        break
+            data_dict['research_question'] = rq_ids
+        elif isinstance(research_questions, unicode):
+            for rq in rq_options:
+                if rq.get('text') == research_questions:
+                    data_dict['research_question'] = [rq.get('id')]
+                    break
+
+    return ckan_package_update(context, data_dict)

--- a/ckanext/knowledgehub/plugin.py
+++ b/ckanext/knowledgehub/plugin.py
@@ -164,6 +164,7 @@ class KnowledgehubPlugin(plugins.SingletonPlugin, DefaultDatasetForm):
     def before_index(self, pkg_dict):
         research_question = pkg_dict.get('research_question')
 
+        # Store the titles of RQs instead of ids so they are searchable
         if research_question:
             rq_titles = []
 

--- a/ckanext/knowledgehub/plugin.py
+++ b/ckanext/knowledgehub/plugin.py
@@ -15,6 +15,7 @@ class KnowledgehubPlugin(plugins.SingletonPlugin, DefaultDatasetForm):
     plugins.implements(plugins.ITemplateHelpers)
     plugins.implements(plugins.IDatasetForm)
     plugins.implements(plugins.IRoutes, inherit=True)
+    plugins.implements(plugins.IPackageController, inherit=True)
 
     # IConfigurer
     def update_config(self, config_):
@@ -158,3 +159,30 @@ class KnowledgehubPlugin(plugins.SingletonPlugin, DefaultDatasetForm):
         map.redirect('/', '/dataset',
                      _redirect_code='301 Moved Permanently')
         return map
+
+    # IPackageController
+    def before_index(self, pkg_dict):
+        research_question = pkg_dict.get('research_question')
+
+        if research_question:
+            rq_titles = []
+
+            # Remove `{` from the beginning
+            research_question = research_question[1:]
+
+            # Remove `}` from the end
+            research_question = research_question[:-1]
+
+            rq_ids = research_question.split(',')
+
+            for rq_id in rq_ids:
+                try:
+                    rq = toolkit.get_action('research_question_show')({}, {'id': rq_id})
+                    rq_titles.append(rq.get('title'))
+                except logic.NotFound:
+                    continue
+
+            pkg_dict['research_question'] = ','.join(rq_titles)
+            pkg_dict['extras_research_question'] = ','.join(rq_titles)
+
+        return pkg_dict

--- a/ckanext/knowledgehub/plugin.py
+++ b/ckanext/knowledgehub/plugin.py
@@ -65,7 +65,8 @@ class KnowledgehubPlugin(plugins.SingletonPlugin, DefaultDatasetForm):
             'get_rq': h.get_rq,
             'resource_view_icon': h.resource_view_icon,
             'get_last_visuals': h.get_last_visuals,
-            'pg_array_to_py_list': h.pg_array_to_py_list
+            'pg_array_to_py_list': h.pg_array_to_py_list,
+            'rq_ids_to_titles': h.rq_ids_to_titles,
         }
 
     # IDatasetForm

--- a/ckanext/knowledgehub/templates/package/snippets/package_metadata_fields.html
+++ b/ckanext/knowledgehub/templates/package/snippets/package_metadata_fields.html
@@ -51,6 +51,7 @@
 
     {% if data.research_question %}
       {% set selected_rq = h.pg_array_to_py_list(data.research_question) %}
+      {% set selected_rq = h.rq_ids_to_titles(selected_rq) %}
     {% endif %}
 
     {{ form.selectmulti('research_question', label=_('Research question'), options=rq_options, selected=selected_rq, id='field-research_question', error=errors.research_question, attrs={"multiple": "multiple", "data-module": "autocomplete"}, classes=['control-medium']) }}


### PR DESCRIPTION
This PR changes how RQs are stored in the database for a dataset. Previously the titles were stored, and now the ids. Also, in Solr, the titles are stored so they can be searchable.