### PR TITLE
Fix errors on Datasets page

### DIFF
--- a/ckanext/knowledgehub/logic/auth/create.py
+++ b/ckanext/knowledgehub/logic/auth/create.py
@@ -1,3 +1,5 @@
+from ckan.logic.auth.create import package_create as ckan_package_create
+
 
 def theme_create(context, data_dict):
     '''
@@ -40,3 +42,9 @@ def resource_feedback(context, data_dict):
     '''
     # all users
     return {'success': True}
+
+
+def package_create(context, data_dict=None):
+    # This auth function must be overriden like this, otherwise a recursion
+    # error is thrown when the /dataset page is accessed by a regular user
+    return ckan_package_create(context, data_dict)

--- a/ckanext/knowledgehub/logic/auth/update.py
+++ b/ckanext/knowledgehub/logic/auth/update.py
@@ -1,3 +1,4 @@
+from ckan.logic.auth.update import package_update as ckan_package_update
 
 def theme_update(context, data_dict):
     '''
@@ -33,3 +34,9 @@ def dashboard_update(context, data_dict):
     '''
     # sysadmins only
     return {'success': False}
+
+
+def package_update(context, data_dict=None):
+    # This auth function must be overriden like this, otherwise an error is
+    # thrown in a dataset page for a regular user.
+    return ckan_package_update(context, data_dict)

--- a/ckanext/knowledgehub/templates/dashboard/snippets/helper.html
+++ b/ckanext/knowledgehub/templates/dashboard/snippets/helper.html
@@ -5,7 +5,7 @@
   </h2>
   <div class="module-content">
     <p>
-      {% trans %} Dashboards are ... {% endtrans %}
+      {% trans %} Dashboards provide a way for the user to have an overview of data. The data is visualized in charts, maps and tables. {% endtrans %}
     </p>
   </div>
 </div>


### PR DESCRIPTION
This PR fixes a recursion error that was thrown for a regular user on the Datasets page and also other error when accessed a specific dataset page.