### PR TITLE
Feature/predictive search

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This is the main repo for the Knowledge Hub on Displaced Populations in the MENA
      - [Requirements](#requirements)
      - [Additional Requirements](#additional-requirements)
      - [Installation](#installation)
-     - [Config Settings](#config-settings)  
+     - [Config Settings](#config-settings)
  - [Development](#development)
      - [Development Installation](#development-installation)
      - [Modify CSS](#modify-css)
@@ -20,7 +20,7 @@ This is the main repo for the Knowledge Hub on Displaced Populations in the MENA
 
 ### Requirements
 
-This extension requires CKAN 2.8.x version. 
+This extension requires CKAN 2.8.x version.
 
 
 ### Additional Requirements
@@ -68,7 +68,7 @@ These are the required configuration options used by the extension:
 ckanext.knowledgehub.themes_per_page = 20
 ```
 2. The number of sub-themes shown per page
- ```  
+ ```
 # (optional, default: 10).
 ckanext.knowledgehub.sub_themes_per_page = 20
 ```
@@ -77,6 +77,42 @@ ckanext.knowledgehub.sub_themes_per_page = 20
 # (optional, default: 10).
 ckanext.knowledgehub.dashboards_per_page = 20
 ```
+4. Predictive Search
+     - Length of the seuqunce after which the model can start predict
+     ```
+     # (optional, default: 15)
+     ckanext.knowledgehub.rnn.sequence_length = 12
+     ```
+     - Number of chars to be skipped in generation of next sentence
+     ```
+     # (optional, default: 3)
+     ckanext.knowledgehub.rnn.sentence_step = 2
+     ```
+     - Number of predictions to return
+     ```
+     # (optional, default: 3)
+     ckanext.knowledgehub.rnn.number_prediction = 2
+     ```
+     - Minimum length of the corpus after it should start to predict
+     ```
+     # (optional, default: 3)
+     ckanext.knowledgehub.rnn.min_length_corpus = 300
+     ```
+     - Maximum epochs to learn
+     ```
+     # (optional, default: 50)
+     ckanext.knowledgehub.rnn.max_epochs = 30
+     ```
+     - Full path to the RNN model
+     ```
+     # (optional, default: ./keras_model.h5)
+     ckanext.knowledgehub.rnn.model = /home/user/model.h5
+     ```
+     - Full path to the model history
+     ```
+     # (optional, default: ./history.p)
+     ckanext.knowledgehub.rnn.history = /home/user/history.p
+     ```
 
 # Development
 

--- a/README.md
+++ b/README.md
@@ -52,10 +52,16 @@ pip install ckanext-knowledgehub
    config file (by default the config file is located at
    ``/etc/ckan/default/production.ini``).
 
-4. Restart CKAN. For example if you've deployed CKAN with Apache on Ubuntu:
+5. Restart CKAN. For example if you've deployed CKAN with Apache on Ubuntu:
 
 ```
 sudo service apache2 reload
+```
+
+6. Run the background job for predictive search periodically( daily or weekly is recommended ):
+
+```
+paster --plugin=ckan jobs worker predictive-search -c /etc/ckan/default/production.ini
 ```
 
 ### Config Settings
@@ -78,9 +84,9 @@ ckanext.knowledgehub.sub_themes_per_page = 20
 ckanext.knowledgehub.dashboards_per_page = 20
 ```
 4. Predictive Search
-     - Length of the seuqunce after which the model can start predict
+     - Length of the seuqunce after which the model can start predict, recommended at least 15 chars long
      ```
-     # (optional, default: 15)
+     # (optional, default: 10)
      ckanext.knowledgehub.rnn.sequence_length = 12
      ```
      - Number of chars to be skipped in generation of next sentence

--- a/ckanext/knowledgehub/cli/db.py
+++ b/ckanext/knowledgehub/cli/db.py
@@ -11,6 +11,9 @@ from ckanext.knowledgehub.model.dashboard import setup as dashboard_db_setup
 from ckanext.knowledgehub.model.resource_feedback import (
     setup as resource_feedback_setup
 )
+from ckanext.knowledgehub.model.kwh_data import (
+    setup as kwh_data_setup
+)
 
 log = logging.getLogger(__name__)
 
@@ -30,6 +33,7 @@ def init():
         rq_db_setup()
         dashboard_db_setup()
         resource_feedback_setup()
+        kwh_data_setup()
     except Exception as e:
         error_shout(e)
     else:

--- a/ckanext/knowledgehub/cli/db.py
+++ b/ckanext/knowledgehub/cli/db.py
@@ -8,6 +8,7 @@ from ckanext.knowledgehub.model.theme import theme_db_setup
 from ckanext.knowledgehub.model.research_question import setup as rq_db_setup
 from ckanext.knowledgehub.model.sub_theme import setup as sub_theme_db_setup
 from ckanext.knowledgehub.model.dashboard import setup as dashboard_db_setup
+from ckanext.knowledgehub.model.rnn_corpus import setup as rnn_corpus_setup
 from ckanext.knowledgehub.model.resource_feedback import (
     setup as resource_feedback_setup
 )
@@ -34,6 +35,7 @@ def init():
         dashboard_db_setup()
         resource_feedback_setup()
         kwh_data_setup()
+        rnn_corpus_setup()
     except Exception as e:
         error_shout(e)
     else:

--- a/ckanext/knowledgehub/controllers/__init__.py
+++ b/ckanext/knowledgehub/controllers/__init__.py
@@ -1,0 +1,5 @@
+from ckanext.knowledgehub.controllers.package import KWHPackageController
+
+__all__ = [
+    'KWHPackageController'
+]

--- a/ckanext/knowledgehub/controllers/package.py
+++ b/ckanext/knowledgehub/controllers/package.py
@@ -5,6 +5,7 @@ from six import string_types
 from paste.deploy.converters import asbool
 
 from ckan.controllers.package import PackageController
+from ckan.controllers.admin import get_sysadmins
 import ckan.logic as logic
 import ckan.model as model
 from ckan.common import c, request, OrderedDict, _
@@ -49,12 +50,17 @@ class KWHPackageController(PackageController):
         # Store search query in KWH data
         try:
             if q:
+                sysadmin = get_sysadmins()[0].name
+                kwh_data_context = {
+                    'user': sysadmin,
+                    'ignore_auth': True
+                }
                 kwh_data = {
                     'type': 'search',
                     'content': q
                 }
                 logic.get_action(u'kwh_data_create')(
-                    context, kwh_data
+                    kwh_data_context, kwh_data
                 )
         except Exception as e:
             log.debug('Error while storing KWH data: %s' % str(e))

--- a/ckanext/knowledgehub/controllers/package.py
+++ b/ckanext/knowledgehub/controllers/package.py
@@ -1,3 +1,5 @@
+import logging
+
 from urllib import urlencode
 from six import string_types
 from paste.deploy.converters import asbool
@@ -17,6 +19,8 @@ NotAuthorized = logic.NotAuthorized
 check_access = logic.check_access
 get_action = logic.get_action
 render = base.render
+
+log = logging.getLogger(__name__)
 
 
 def _encode_params(params):

--- a/ckanext/knowledgehub/controllers/package.py
+++ b/ckanext/knowledgehub/controllers/package.py
@@ -1,0 +1,242 @@
+from urllib import urlencode
+from six import string_types
+from paste.deploy.converters import asbool
+
+from ckan.controllers.package import PackageController
+import ckan.logic as logic
+import ckan.model as model
+from ckan.common import c, request, OrderedDict, _
+import ckan.lib.helpers as h
+from ckan.common import config
+import ckan.plugins as p
+import ckan.lib.base as base
+
+
+NotFound = logic.NotFound
+NotAuthorized = logic.NotAuthorized
+check_access = logic.check_access
+get_action = logic.get_action
+render = base.render
+
+
+def _encode_params(params):
+    return [(k, v.encode('utf-8') if isinstance(v, string_types) else str(v))
+            for k, v in params]
+
+
+class KWHPackageController(PackageController):
+    """Overrides CKAN's PackageController to store searched data
+    """
+
+    def search(self):
+        from ckan.lib.search import SearchError, SearchQueryError
+
+        package_type = self._guess_package_type()
+
+        try:
+            context = {'model': model, 'user': c.user,
+                       'auth_user_obj': c.userobj}
+            check_access('site_read', context)
+        except NotAuthorized:
+            abort(403, _('Not authorized to see this page'))
+
+        # unicode format (decoded from utf8)
+        q = c.q = request.params.get('q', u'')
+        # Store search query in KWH data
+        try:
+            if q:
+                kwh_data = {
+                    'type': 'search',
+                    'content': q
+                }
+                logic.get_action(u'kwh_data_create')(
+                    context, kwh_data
+                )
+        except Exception as e:
+            log.debug('Error while storing KWH data: %s' % str(e))
+
+        c.query_error = False
+        page = h.get_page_number(request.params)
+
+        limit = int(config.get('ckan.datasets_per_page', 20))
+
+        # most search operations should reset the page counter:
+        params_nopage = [(k, v) for k, v in request.params.items()
+                         if k != 'page']
+
+        def drill_down_url(alternative_url=None, **by):
+            return h.add_url_param(alternative_url=alternative_url,
+                                   controller='package', action='search',
+                                   new_params=by)
+
+        c.drill_down_url = drill_down_url
+
+        def remove_field(key, value=None, replace=None):
+            return h.remove_url_param(key, value=value, replace=replace,
+                                      controller='package', action='search',
+                                      alternative_url=package_type)
+
+        c.remove_field = remove_field
+
+        sort_by = request.params.get('sort', None)
+        params_nosort = [(k, v) for k, v in params_nopage if k != 'sort']
+
+        def _sort_by(fields):
+            """
+            Sort by the given list of fields.
+
+            Each entry in the list is a 2-tuple: (fieldname, sort_order)
+
+            eg - [('metadata_modified', 'desc'), ('name', 'asc')]
+
+            If fields is empty, then the default ordering is used.
+            """
+            params = params_nosort[:]
+
+            if fields:
+                sort_string = ', '.join('%s %s' % f for f in fields)
+                params.append(('sort', sort_string))
+            return search_url(params, package_type)
+
+        c.sort_by = _sort_by
+        if not sort_by:
+            c.sort_by_fields = []
+        else:
+            c.sort_by_fields = [field.split()[0]
+                                for field in sort_by.split(',')]
+
+        def pager_url(q=None, page=None):
+            params = list(params_nopage)
+            params.append(('page', page))
+            return search_url(params, package_type)
+
+        c.search_url_params = urlencode(_encode_params(params_nopage))
+
+        try:
+            c.fields = []
+            # c.fields_grouped will contain a dict of params containing
+            # a list of values eg {'tags':['tag1', 'tag2']}
+            c.fields_grouped = {}
+            search_extras = {}
+            fq = ''
+            for (param, value) in request.params.items():
+                if param not in ['q', 'page', 'sort'] \
+                        and len(value) and not param.startswith('_'):
+                    if not param.startswith('ext_'):
+                        c.fields.append((param, value))
+                        fq += ' %s:"%s"' % (param, value)
+                        if param not in c.fields_grouped:
+                            c.fields_grouped[param] = [value]
+                        else:
+                            c.fields_grouped[param].append(value)
+                    else:
+                        search_extras[param] = value
+
+            context = {'model': model, 'session': model.Session,
+                       'user': c.user, 'for_view': True,
+                       'auth_user_obj': c.userobj}
+
+            # Unless changed via config options, don't show other dataset
+            # types any search page. Potential alternatives are do show them
+            # on the default search page (dataset) or on one other search page
+            search_all_type = config.get(
+                                  'ckan.search.show_all_types', 'dataset')
+            search_all = False
+
+            try:
+                # If the "type" is set to True or False, convert to bool
+                # and we know that no type was specified, so use traditional
+                # behaviour of applying this only to dataset type
+                search_all = asbool(search_all_type)
+                search_all_type = 'dataset'
+            # Otherwise we treat as a string representing a type
+            except ValueError:
+                search_all = True
+
+            if not package_type:
+                package_type = 'dataset'
+
+            if not search_all or package_type != search_all_type:
+                # Only show datasets of this particular type
+                fq += ' +dataset_type:{type}'.format(type=package_type)
+
+            facets = OrderedDict()
+
+            default_facet_titles = {
+                'organization': _('Organizations'),
+                'groups': _('Groups'),
+                'tags': _('Tags'),
+                'res_format': _('Formats'),
+                'license_id': _('Licenses'),
+                }
+
+            for facet in h.facets():
+                if facet in default_facet_titles:
+                    facets[facet] = default_facet_titles[facet]
+                else:
+                    facets[facet] = facet
+
+            # Facet titles
+            for plugin in p.PluginImplementations(p.IFacets):
+                facets = plugin.dataset_facets(facets, package_type)
+
+            c.facet_titles = facets
+
+            data_dict = {
+                'q': q,
+                'fq': fq.strip(),
+                'facet.field': facets.keys(),
+                'rows': limit,
+                'start': (page - 1) * limit,
+                'sort': sort_by,
+                'extras': search_extras,
+                'include_private': asbool(config.get(
+                    'ckan.search.default_include_private', True)),
+            }
+
+            query = get_action('package_search')(context, data_dict)
+            c.sort_by_selected = query['sort']
+
+            c.page = h.Page(
+                collection=query['results'],
+                page=page,
+                url=pager_url,
+                item_count=query['count'],
+                items_per_page=limit
+            )
+            c.search_facets = query['search_facets']
+            c.page.items = query['results']
+        except SearchQueryError as se:
+            # User's search parameters are invalid, in such a way that is not
+            # achievable with the web interface, so return a proper error to
+            # discourage spiders which are the main cause of this.
+            log.info('Dataset search query rejected: %r', se.args)
+            abort(400, _('Invalid search query: {error_message}')
+                  .format(error_message=str(se)))
+        except SearchError as se:
+            # May be bad input from the user, but may also be more serious like
+            # bad code causing a SOLR syntax error, or a problem connecting to
+            # SOLR
+            log.error('Dataset search error: %r', se.args)
+            c.query_error = True
+            c.search_facets = {}
+            c.page = h.Page(collection=[])
+        except NotAuthorized:
+            abort(403, _('Not authorized to see this page'))
+
+        c.search_facets_limits = {}
+        for facet in c.search_facets.keys():
+            try:
+                limit = int(request.params.get('_%s_limit' % facet,
+                            int(config.get('search.facets.default', 10))))
+            except ValueError:
+                abort(400, _('Parameter "{parameter_name}" is not '
+                             'an integer').format(
+                      parameter_name='_%s_limit' % facet))
+            c.search_facets_limits[facet] = limit
+
+        self._setup_template_variables(context, {},
+                                       package_type=package_type)
+
+        return render(self._search_template(package_type),
+                      extra_vars={'dataset_type': package_type})

--- a/ckanext/knowledgehub/fanstatic/javascript/search_prediction.js
+++ b/ckanext/knowledgehub/fanstatic/javascript/search_prediction.js
@@ -3,6 +3,7 @@
 
     var timer = null;
     var currentFocus;
+    var searchInput = $('#field-giant-search');
 
     var api = {
         get: function (action, params, async) {
@@ -26,23 +27,21 @@
     };
 
     function addActive(x) {
-        /*a function to classify an item as "active":*/
+        // Add active class to active item in the list
         if (!x) return false;
-        /*start by removing the "active" class on all items:*/
         removeActive(x);
         if (currentFocus >= x.length) currentFocus = 0;
         if (currentFocus < 0) currentFocus = (x.length - 1);
-        /*add class "autocomplete-active":*/
         x[currentFocus].classList.add("autocomplete-active");
     }
     function removeActive(x) {
-        /*a function to remove the "active" class from all autocomplete items:*/
+         // Remove active class from an item
         for (var i = 0; i < x.length; i++) {
             x[i].classList.remove("autocomplete-active");
         }
     }
     function closeAllLists(elmnt) {
-        /*close all autocomplete lists in the document, except the one passed as an argument:*/
+        // Close all autocomplete lists in the document
         var x = document.getElementsByClassName("autocomplete-items");
         for (var i = 0; i < x.length; i++) {
             if (elmnt != x[i]) {
@@ -54,13 +53,13 @@
     $(document).ready(function () {
         currentFocus = -1;
 
-        $('#field-giant-search')
+        searchInput
             .bind("change keyup", function (event) {
                 clearTimeout(timer)
                 if (!(event.keyCode >= 13 && event.keyCode <= 20) && !(event.keyCode >= 37 && event.keyCode <= 40)) {
                     // detect that user has stopped typing for a while
                     timer = setTimeout(function() {
-                        var text = $('#field-giant-search').val();
+                        var text = searchInput.val();
 
                         if (text !== '') {
                             api.get('get_predictions', {
@@ -68,24 +67,22 @@
                             }, true)
                             .done(function (data) {
                                 if (data.success) {
+                                    var a, b;
+                                    var results = data.result;
+
                                     closeAllLists()
-                                    /*create a DIV element that will contain the items (values):*/
-                                    var a, b, i;
+
                                     a = document.createElement("DIV");
                                     a.setAttribute("id", "autocomplete-list");
                                     a.setAttribute("class", "autocomplete-items");
-                                    $('#field-giant-search').after(a);
+                                    searchInput.after(a);
 
-                                    var results = data.result;
                                     results.forEach(function (r) {
                                         b = document.createElement("DIV");
                                         b.innerHTML = text;
                                         b.innerHTML += "<strong>" + r + "</strong>";
                                         b.addEventListener("click", function (e) {
-                                            /*insert the value for the autocomplete text field:*/
-                                            $('#field-giant-search').val(text + r);
-                                            /*close the list of autocompleted values,
-                                            or any other open lists of autocompleted values:*/
+                                            searchInput.val(text + r);
                                             closeAllLists();
                                         });
                                         a.append(b)
@@ -101,26 +98,21 @@
             })
     });
 
-    $('#field-giant-search').on('keydown', function (e) {
+    searchInput.on('keydown', function (e) {
         var x = document.getElementById("autocomplete-list");
         if (x) x = x.getElementsByTagName("div");
         if (e.keyCode == 40) {
-            /*If the arrow DOWN key is pressed,
-            increase the currentFocus variable:*/
+            // The arrow DOWN key is pressed
             currentFocus++;
-            /*and and make the current item more visible:*/
             addActive(x);
-        } else if (e.keyCode == 38) { //up
-            /*If the arrow UP key is pressed,
-            decrease the currentFocus variable:*/
+        } else if (e.keyCode == 38) {
+            // The arrow UP key is pressed
             currentFocus--;
-            /*and and make the current item more visible:*/
             addActive(x);
         } else if (e.keyCode == 13) {
-            /*If the ENTER key is pressed, prevent the form from being submitted,*/
-            // e.preventDefault();
+            // ENTER key is pressed
             if (currentFocus > -1) {
-                /*and simulate a click on the "active" item:*/
+                // simulate a click on the "active" item*
                 if (x) x[currentFocus].click();
             }
         }

--- a/ckanext/knowledgehub/fanstatic/javascript/search_prediction.js
+++ b/ckanext/knowledgehub/fanstatic/javascript/search_prediction.js
@@ -1,0 +1,57 @@
+(function (_, jQuery) {
+    'use strict';
+
+    var timer = null;
+
+    var api = {
+        get: function (action, params, async) {
+            var api_ver = 3;
+            var base_url = ckan.sandbox().client.endpoint;
+            params = $.param(params);
+            var url = base_url + '/api/' + api_ver + '/action/' + action + '?' + params;
+            if (!async) {
+                $.ajaxSetup({
+                    async: false
+                });
+            }
+            return $.getJSON(url);
+        },
+        post: function (action, data) {
+            var api_ver = 3;
+            var base_url = ckan.sandbox().client.endpoint;
+            var url = base_url + '/api/' + api_ver + '/action/' + action;
+            return $.post(url, data, 'json');
+        }
+    };
+
+    $(document).ready(function () {
+        $('#field-giant-search')
+            .bind("change keyup", function (event) {
+                clearTimeout(timer)
+                if (event.keyCode !== 13) {
+                    // detect that user has stopped typing for a while
+                    timer = setTimeout(function() {
+                        var text = $('#field-giant-search').val();
+                        console.log('User input: ' + text)
+
+                        if (text !== '') {
+                            api.get('get_predictions', {
+                                text: text
+                            }, true)
+                            .done(function (data) {
+                                if (data.success) {
+                                    var results = data.result;
+                                    results.forEach(function (r) {
+                                        console.log(text + r);
+                                    });
+                                }
+                            })
+                            .fail(function (error) {
+                                console.log("Get predictions: " + error.statusText);
+                            });
+                        }
+                    }, 500);
+                }
+            })
+    });
+})(ckan.i18n.ngettext, $);

--- a/ckanext/knowledgehub/fanstatic/javascript/search_prediction.js
+++ b/ckanext/knowledgehub/fanstatic/javascript/search_prediction.js
@@ -2,6 +2,7 @@
     'use strict';
 
     var timer = null;
+    var currentFocus;
 
     var api = {
         get: function (action, params, async) {
@@ -24,11 +25,39 @@
         }
     };
 
+    function addActive(x) {
+        /*a function to classify an item as "active":*/
+        if (!x) return false;
+        /*start by removing the "active" class on all items:*/
+        removeActive(x);
+        if (currentFocus >= x.length) currentFocus = 0;
+        if (currentFocus < 0) currentFocus = (x.length - 1);
+        /*add class "autocomplete-active":*/
+        x[currentFocus].classList.add("autocomplete-active");
+    }
+    function removeActive(x) {
+        /*a function to remove the "active" class from all autocomplete items:*/
+        for (var i = 0; i < x.length; i++) {
+            x[i].classList.remove("autocomplete-active");
+        }
+    }
+    function closeAllLists(elmnt) {
+        /*close all autocomplete lists in the document, except the one passed as an argument:*/
+        var x = document.getElementsByClassName("autocomplete-items");
+        for (var i = 0; i < x.length; i++) {
+            if (elmnt != x[i]) {
+                x[i].parentNode.removeChild(x[i]);
+            }
+        }
+    }
+
     $(document).ready(function () {
+        currentFocus = -1;
+
         $('#field-giant-search')
             .bind("change keyup", function (event) {
                 clearTimeout(timer)
-                if (event.keyCode !== 13) {
+                if (!(event.keyCode >= 13 && event.keyCode <= 20) && !(event.keyCode >= 37 && event.keyCode <= 40)) {
                     // detect that user has stopped typing for a while
                     timer = setTimeout(function() {
                         var text = $('#field-giant-search').val();
@@ -40,9 +69,27 @@
                             }, true)
                             .done(function (data) {
                                 if (data.success) {
+                                    closeAllLists()
+                                    /*create a DIV element that will contain the items (values):*/
+                                    var a, b, i;
+                                    a = document.createElement("DIV");
+                                    a.setAttribute("id", "autocomplete-list");
+                                    a.setAttribute("class", "autocomplete-items");
+                                    $('#field-giant-search').append(a);
+
                                     var results = data.result;
                                     results.forEach(function (r) {
-                                        console.log(text + r);
+                                        b = document.createElement("DIV");
+                                        b.innerHTML = text;
+                                        b.innerHTML += "<strong>" + r + "</strong>";
+                                        b.addEventListener("click", function (e) {
+                                            /*insert the value for the autocomplete text field:*/
+                                            $('#field-giant-search').val(text + r);
+                                            /*close the list of autocompleted values,
+                                            or any other open lists of autocompleted values:*/
+                                            closeAllLists();
+                                        });
+                                        a.append(b)
                                     });
                                 }
                             })
@@ -53,5 +100,31 @@
                     }, 500);
                 }
             })
+    });
+
+    $('#field-giant-search').on('keydown', function (e) {
+        console.log(e.keyCode)
+        var x = document.getElementById("autocomplete-list");
+        if (x) x = x.getElementsByTagName("div");
+        if (e.keyCode == 40) {
+            /*If the arrow DOWN key is pressed,
+            increase the currentFocus variable:*/
+            currentFocus++;
+            /*and and make the current item more visible:*/
+            addActive(x);
+        } else if (e.keyCode == 38) { //up
+            /*If the arrow UP key is pressed,
+            decrease the currentFocus variable:*/
+            currentFocus--;
+            /*and and make the current item more visible:*/
+            addActive(x);
+        } else if (e.keyCode == 13) {
+            /*If the ENTER key is pressed, prevent the form from being submitted,*/
+            // e.preventDefault();
+            if (currentFocus > -1) {
+                /*and simulate a click on the "active" item:*/
+                if (x) x[currentFocus].click();
+            }
+        }
     });
 })(ckan.i18n.ngettext, $);

--- a/ckanext/knowledgehub/fanstatic/javascript/search_prediction.js
+++ b/ckanext/knowledgehub/fanstatic/javascript/search_prediction.js
@@ -61,7 +61,6 @@
                     // detect that user has stopped typing for a while
                     timer = setTimeout(function() {
                         var text = $('#field-giant-search').val();
-                        console.log('User input: ' + text)
 
                         if (text !== '') {
                             api.get('get_predictions', {
@@ -75,7 +74,7 @@
                                     a = document.createElement("DIV");
                                     a.setAttribute("id", "autocomplete-list");
                                     a.setAttribute("class", "autocomplete-items");
-                                    $('#field-giant-search').append(a);
+                                    $('#field-giant-search').after(a);
 
                                     var results = data.result;
                                     results.forEach(function (r) {
@@ -103,7 +102,6 @@
     });
 
     $('#field-giant-search').on('keydown', function (e) {
-        console.log(e.keyCode)
         var x = document.getElementById("autocomplete-list");
         if (x) x = x.getElementsByTagName("div");
         if (e.keyCode == 40) {

--- a/ckanext/knowledgehub/helpers.py
+++ b/ckanext/knowledgehub/helpers.py
@@ -635,12 +635,22 @@ def get_dashboards(limit=5, order_by='created_by asc'):
     return dashboards
 
 
-def predict_completions(text, n=3):
-    sequence = int(config.get(u'ckanext.knowledgehub.rnn.sequence_length', 10))
-    if sequence > len(text):
-        return []
+def get_kwh_data():
+    corpus = ''
+    try:
+        kwh_data = toolkit.get_action('kwh_data_list')({}, {})
+    except Exception as e:
+        log.debug('Error while loading KnowledgeHub data: %s' % str(e))
+        return corpus
 
-    seq = text[-sequence:].lower()
+    if kwh_data.get('total'):
+        data = kwh_data.get('data', [])
+        for entry in data:
+            corpus += ' %s' % entry.get('content')
+
+    return corpus
+
+
+def predict_completions(text):
     print text
-    print seq
-    print rnn_helpers.predict_completions(seq, 3)
+    print rnn_helpers.predict_completions(text)

--- a/ckanext/knowledgehub/helpers.py
+++ b/ckanext/knowledgehub/helpers.py
@@ -649,8 +649,3 @@ def get_kwh_data():
             corpus += ' %s' % entry.get('content')
 
     return corpus
-
-
-def predict_completions(text):
-    print text
-    print rnn_helpers.predict_completions(text)

--- a/ckanext/knowledgehub/helpers.py
+++ b/ckanext/knowledgehub/helpers.py
@@ -23,7 +23,9 @@ from ckan import logic
 from ckan.model import ResourceView, Resource
 from ckan import lib
 
+from ckanext.knowledgehub.rnn import helpers as rnn_helpers
 from ckanext.knowledgehub.model import Dashboard
+
 
 log = logging.getLogger(__name__)
 model_dictize = lib.dictization.model_dictize
@@ -631,3 +633,14 @@ def get_dashboards(limit=5, order_by='created_by asc'):
     dashboards = Dashboard.search(limit=limit, order_by=order_by).all()
 
     return dashboards
+
+
+def predict_completions(text, n=3):
+    sequence = int(config.get(u'ckanext.knowledgehub.rnn.sequence_length', 10))
+    if sequence > len(text):
+        return []
+
+    seq = text[-sequence:].lower()
+    print text
+    print seq
+    print rnn_helpers.predict_completions(seq, 3)

--- a/ckanext/knowledgehub/logic/action/create.py
+++ b/ckanext/knowledgehub/logic/action/create.py
@@ -24,6 +24,7 @@ from ckanext.knowledgehub.model import ResearchQuestion
 from ckanext.knowledgehub.model import Dashboard
 from ckanext.knowledgehub.model import ResourceFeedbacks
 from ckanext.knowledgehub.model import KWHData
+from ckanext.knowledgehub.model import RNNCorpus
 from ckanext.knowledgehub.backend.factory import get_backend
 from ckanext.knowledgehub.lib.writer import WriterService
 from ckanext.knowledgehub import helpers as plugin_helpers
@@ -437,3 +438,25 @@ def kwh_data_create(context, data_dict):
         kwh_data = KWHData(**data)
         kwh_data.save()
         return kwh_data.as_dict()
+
+
+def corpus_create(context, data_dict):
+    '''
+    Store RNN corpus
+
+        :param corpus
+    '''
+    check_access('corpus_create', context, data_dict)
+
+    session = context['session']
+
+    data, errors = _df.validate(data_dict,
+                                knowledgehub_schema.corpus_create(),
+                                context)
+
+    if errors:
+        raise ValidationError(errors)
+
+    corpus = RNNCorpus(**data)
+    corpus.save()
+    return corpus.as_dict()

--- a/ckanext/knowledgehub/logic/action/create.py
+++ b/ckanext/knowledgehub/logic/action/create.py
@@ -414,7 +414,7 @@ def kwh_data_create(context, data_dict):
         :param type
         :param content
     '''
-    # check_access('kwh_data', context, data_dict)
+    check_access('kwh_data', context, data_dict)
 
     session = context['session']
 

--- a/ckanext/knowledgehub/logic/action/create.py
+++ b/ckanext/knowledgehub/logic/action/create.py
@@ -406,7 +406,7 @@ def resource_feedback(context, data_dict):
         return rf.as_dict()
 
 
-def kwh_data(context, data_dict):
+def kwh_data_create(context, data_dict):
     '''
     Store Knowledge Hub data
 
@@ -427,13 +427,13 @@ def kwh_data(context, data_dict):
     user = context.get('user')
     data['user'] = model.User.by_name(user.decode('utf8')).id
 
-    rf = KWHData.get(
+    kwh_data = KWHData.get(
         user=data['user'],
         content=data['content'],
         type=data['type']
     ).first()
 
-    if not rf:
-        rf = KWHData(**data)
-        rf.save()
-        return rf.as_dict()
+    if not kwh_data:
+        kwh_data = KWHData(**data)
+        kwh_data.save()
+        return kwh_data.as_dict()

--- a/ckanext/knowledgehub/logic/action/create.py
+++ b/ckanext/knowledgehub/logic/action/create.py
@@ -414,7 +414,7 @@ def kwh_data_create(context, data_dict):
         :param type
         :param content
     '''
-    check_access('kwh_data', context, data_dict)
+    # check_access('kwh_data', context, data_dict)
 
     session = context['session']
 
@@ -426,12 +426,14 @@ def kwh_data_create(context, data_dict):
         raise ValidationError(errors)
 
     user = context.get('user')
-    data['user'] = model.User.by_name(user.decode('utf8')).id
+    user_data = model.User.by_name(user.decode('utf8'))
+    if user_data:
+        data['user'] = user_data.id
 
     kwh_data = KWHData.get(
-        user=data['user'],
-        content=data['content'],
-        type=data['type']
+        user=data.get('user'),
+        content=data.get('content'),
+        type=data.get('type')
     ).first()
 
     if not kwh_data:

--- a/ckanext/knowledgehub/logic/action/create.py
+++ b/ckanext/knowledgehub/logic/action/create.py
@@ -426,7 +426,6 @@ def kwh_data(context, data_dict):
 
     user = context.get('user')
     data['user'] = model.User.by_name(user.decode('utf8')).id
-    resource = data.get('resource')
 
     rf = KWHData.get(
         user=data['user'],

--- a/ckanext/knowledgehub/logic/action/get.py
+++ b/ckanext/knowledgehub/logic/action/get.py
@@ -13,6 +13,7 @@ from ckanext.knowledgehub.model import SubThemes
 from ckanext.knowledgehub.model import ResearchQuestion
 from ckanext.knowledgehub.model import Dashboard
 from ckanext.knowledgehub.model import ResourceFeedbacks
+from ckanext.knowledgehub.model import KWHData
 from ckanext.knowledgehub import helpers as kh_helpers
 from ckan.lib import helpers as h
 
@@ -602,6 +603,78 @@ def resource_feedback_list(context, data_dict):
 
 
 @toolkit.side_effect_free
-def get_rq_url(context, data_dict):
+def kwh_data_list(context, data_dict):
+    ''' List KnowledgeHub data
 
+    :param type: origin of the data, one of theme, sub-theme,
+        rq and search
+    :type type: string
+    :param content: the actual data
+    :type content: string
+    :param user: the user ID
+    :type user: string
+    :param theme: the theme ID
+    :type theme: string
+    :param sub_theme: the sub-theme ID
+    :type sub_theme: string
+    :param rq: the research question ID
+    :type rq: string
+
+    :returns: a dictionary including total items,
+     page number, items per page and data(KnowledgeHub data)
+    :rtype: dictionary
+    '''
+    data_type = data_dict.get('type', '')
+    content = data_dict.get('content', '')
+    user = data_dict.get('user', '')
+    theme = data_dict.get('theme', '')
+    sub_theme = data_dict.get('sub_theme', '')
+    rq = data_dict.get('rq', '')
+
+    q = data_dict.get('q', '')
+    page_size = int(data_dict.get('pageSize', 1000000))
+    page = int(data_dict.get('page', 1))
+    order_by = data_dict.get('order_by', None)
+    offset = (page - 1) * page_size
+
+    kwargs = {}
+
+    if data_type:
+        kwargs['type'] = data_type
+    if content:
+        kwargs['content'] = content
+    if user:
+        kwargs['user'] = user
+    if theme:
+        kwargs['theme'] = theme
+    if sub_theme:
+        kwargs['sub_theme'] = sub_theme
+    if rq:
+        kwargs['rq'] = rq
+
+    kwargs['q'] = q
+    kwargs['limit'] = page_size
+    kwargs['offset'] = offset
+    kwargs['order_by'] = order_by
+
+    kwh_data = []
+
+    try:
+        db_data = KWHData.get(**kwargs).all()
+    except Exception:
+        return {'total': 0, 'page': page,
+                'pageSize': page_size, 'data': []}
+
+    for entry in db_data:
+        kwh_data.append(_table_dictize(entry, context))
+
+    total = len(kwh_data)
+
+    return {'total': total, 'page': page,
+            'pageSize': page_size, 'data': kwh_data}
+
+
+@toolkit.side_effect_free
+def get_rq_url(context, data_dict):
+    
     return h.url_for('research_question.read', name=data_dict['name'])

--- a/ckanext/knowledgehub/logic/action/get.py
+++ b/ckanext/knowledgehub/logic/action/get.py
@@ -16,6 +16,7 @@ from ckanext.knowledgehub.model import ResourceFeedbacks
 from ckanext.knowledgehub.model import KWHData
 from ckanext.knowledgehub.model import RNNCorpus
 from ckanext.knowledgehub import helpers as kh_helpers
+from ckanext.knowledgehub.rnn import helpers as rnn_helpers
 from ckan.lib import helpers as h
 
 from ckanext.knowledgehub.backend.factory import get_backend
@@ -692,8 +693,23 @@ def get_last_rnn_corpus(context, data_dict):
 
 @toolkit.side_effect_free
 def get_rq_url(context, data_dict):
-    
+
     return h.url_for('research_question.read', name=data_dict['name'])
 
 
+@toolkit.side_effect_free
+def get_predictions(context, data_dict):
+    ''' Returns a list of predictions
 
+    :param text: the text for which predictions have to be made
+    :type text: string
+
+    :returns: predictions
+    :rtype: list
+    '''
+
+    text = data_dict.get('text')
+    if not text:
+        raise ValidationError({'text': _('Missing value')})
+
+    return rnn_helpers.predict_completions(text)

--- a/ckanext/knowledgehub/logic/action/get.py
+++ b/ckanext/knowledgehub/logic/action/get.py
@@ -14,6 +14,7 @@ from ckanext.knowledgehub.model import ResearchQuestion
 from ckanext.knowledgehub.model import Dashboard
 from ckanext.knowledgehub.model import ResourceFeedbacks
 from ckanext.knowledgehub.model import KWHData
+from ckanext.knowledgehub.model import RNNCorpus
 from ckanext.knowledgehub import helpers as kh_helpers
 from ckan.lib import helpers as h
 
@@ -675,6 +676,24 @@ def kwh_data_list(context, data_dict):
 
 
 @toolkit.side_effect_free
+def get_last_rnn_corpus(context, data_dict):
+    ''' Returns last RNN corpus
+
+    :returns: a RNN corpus
+    :rtype: string
+    '''
+
+    c = RNNCorpus.get(order_by='created_at desc', limit=1).first()
+    if not c:
+        raise NotFound(_(u'There is not corpus stored yet!'))
+    else:
+        return c.corpus
+
+
+@toolkit.side_effect_free
 def get_rq_url(context, data_dict):
     
     return h.url_for('research_question.read', name=data_dict['name'])
+
+
+

--- a/ckanext/knowledgehub/logic/action/update.py
+++ b/ckanext/knowledgehub/logic/action/update.py
@@ -20,6 +20,7 @@ from ckanext.knowledgehub.model.theme import Theme
 from ckanext.knowledgehub.model import SubThemes
 from ckanext.knowledgehub.model import ResearchQuestion
 from ckanext.knowledgehub.model import Dashboard
+from ckanext.knowledgehub.model import KWHData
 from ckanext.knowledgehub.backend.factory import get_backend
 from ckanext.knowledgehub.lib.writer import WriterService
 from ckanext.knowledgehub import helpers as plugin_helpers
@@ -345,3 +346,43 @@ def package_update(context, data_dict):
                     break
 
     return ckan_package_update(context, data_dict)
+
+
+def kwh_data_update(context, data_dict):
+    '''
+    Store Knowledge Hub data
+
+        :param type
+        :param old_content
+        :param new_content
+    '''
+    check_access('kwh_data', context, data_dict)
+
+    session = context['session']
+
+    data, errors = _df.validate(data_dict,
+                                knowledgehub_schema.kwh_data_schema_update(),
+                                context)
+
+    if errors:
+        raise ValidationError(errors)
+
+    user = context.get('user')
+    data['user'] = model.User.by_name(user.decode('utf8')).id
+
+    kwh_data = KWHData.get(
+        user=data['user'],
+        content=data['old_content'],
+        type=data['type']
+    ).first()
+
+    if kwh_data:
+        update_data = _table_dictize(kwh_data, context)
+        update_data.pop('id')
+        update_data.pop('created_at')
+        update_data['content'] = data['new_content']
+
+        filter = {'id': kwh_data.id}
+        data = KWHData.update(filter, update_data)
+
+        return data.as_dict()

--- a/ckanext/knowledgehub/logic/auth/create.py
+++ b/ckanext/knowledgehub/logic/auth/create.py
@@ -48,3 +48,12 @@ def package_create(context, data_dict=None):
     # This auth function must be overriden like this, otherwise a recursion
     # error is thrown when the /dataset page is accessed by a regular user
     return ckan_package_create(context, data_dict)
+
+
+def kwh_data(context, data_dict):
+    '''
+        Authorization check for storing KWH data
+    '''
+    # sysadmins only
+    return {'success': False}
+

--- a/ckanext/knowledgehub/logic/auth/create.py
+++ b/ckanext/knowledgehub/logic/auth/create.py
@@ -57,3 +57,11 @@ def kwh_data(context, data_dict):
     # sysadmins only
     return {'success': False}
 
+
+def corpus_create(context, data_dict):
+    '''
+        Authorization check for storing RNN corpus
+    '''
+    # sysadmins only
+    return {'success': False}
+

--- a/ckanext/knowledgehub/logic/auth/create.py
+++ b/ckanext/knowledgehub/logic/auth/create.py
@@ -64,4 +64,3 @@ def corpus_create(context, data_dict):
     '''
     # sysadmins only
     return {'success': False}
-

--- a/ckanext/knowledgehub/logic/schema.py
+++ b/ckanext/knowledgehub/logic/schema.py
@@ -106,3 +106,10 @@ def resource_feedback_schema():
         'dataset': [not_empty, package_id_or_name_exists],
         'resource': [not_empty, resource_id_exists]
     }
+
+
+def kwh_data_schema():
+    return {
+        'type': [not_empty, validators.kwh_data_type_validator],
+        'content': [not_empty, unicode]
+    }

--- a/ckanext/knowledgehub/logic/schema.py
+++ b/ckanext/knowledgehub/logic/schema.py
@@ -111,5 +111,16 @@ def resource_feedback_schema():
 def kwh_data_schema():
     return {
         'type': [not_empty, validators.kwh_data_type_validator],
-        'content': [not_empty, unicode]
+        'content': [not_empty, unicode],
+        'theme': [ignore_missing, unicode],
+        'sub_theme': [ignore_missing, unicode],
+        'rq': [ignore_missing, unicode]
+    }
+
+
+def kwh_data_schema_update():
+    return {
+        'type': [not_empty, validators.kwh_data_type_validator],
+        'old_content': [not_empty, unicode],
+        'new_content': [not_empty, unicode]
     }

--- a/ckanext/knowledgehub/logic/schema.py
+++ b/ckanext/knowledgehub/logic/schema.py
@@ -124,3 +124,9 @@ def kwh_data_schema_update():
         'old_content': [not_empty, unicode],
         'new_content': [not_empty, unicode]
     }
+
+
+def corpus_create():
+    return {
+        'corpus': [not_empty, unicode]
+    }

--- a/ckanext/knowledgehub/logic/validators.py
+++ b/ckanext/knowledgehub/logic/validators.py
@@ -179,3 +179,17 @@ def resource_feedbacks_type_validator(key, data, errors, context):
                 'Allowed resource feedback types are: %s' % ', '.join(rf_types)
             )
         )
+
+
+def kwh_data_type_validator(key, data, errors, context):
+    clean_data = df.unflatten(data)
+    rf_type = clean_data.get('type')
+
+    rf_types = ['theme', 'sub-theme', 'rq', 'user-input']
+
+    if rf_type not in rf_types:
+        errors[key].append(
+            p.toolkit._(
+                'Allowed KWH data types are: %s' % ', '.join(rf_types)
+            )
+        )

--- a/ckanext/knowledgehub/logic/validators.py
+++ b/ckanext/knowledgehub/logic/validators.py
@@ -185,7 +185,7 @@ def kwh_data_type_validator(key, data, errors, context):
     clean_data = df.unflatten(data)
     rf_type = clean_data.get('type')
 
-    rf_types = ['theme', 'sub-theme', 'rq', 'user-input']
+    rf_types = ['theme', 'sub-theme', 'rq', 'search']
 
     if rf_type not in rf_types:
         errors[key].append(

--- a/ckanext/knowledgehub/model/__init__.py
+++ b/ckanext/knowledgehub/model/__init__.py
@@ -4,6 +4,7 @@ from ckanext.knowledgehub.model.research_question import ResearchQuestion
 from ckanext.knowledgehub.model.dashboard import Dashboard
 from ckanext.knowledgehub.model.resource_feedback import ResourceFeedbacks
 from ckanext.knowledgehub.model.kwh_data import KWHData
+from ckanext.knowledgehub.model.rnn_corpus import RNNCorpus
 
 
 __all__ = [
@@ -12,5 +13,6 @@ __all__ = [
     'ResearchQuestion',
     'Dashboard',
     'ResourceFeedbacks',
-    'KWHData'
+    'KWHData',
+    'RNNCorpus'
 ]

--- a/ckanext/knowledgehub/model/__init__.py
+++ b/ckanext/knowledgehub/model/__init__.py
@@ -3,6 +3,7 @@ from ckanext.knowledgehub.model.sub_theme import SubThemes
 from ckanext.knowledgehub.model.research_question import ResearchQuestion
 from ckanext.knowledgehub.model.dashboard import Dashboard
 from ckanext.knowledgehub.model.resource_feedback import ResourceFeedbacks
+from ckanext.knowledgehub.model.kwh_data import KWHData
 
 
 __all__ = [
@@ -10,5 +11,6 @@ __all__ = [
     'SubThemes',
     'ResearchQuestion',
     'Dashboard',
-    'ResourceFeedbacks'
+    'ResourceFeedbacks',
+    'KWHData'
 ]

--- a/ckanext/knowledgehub/model/kwh_data.py
+++ b/ckanext/knowledgehub/model/kwh_data.py
@@ -36,12 +36,13 @@ class KWHData(DomainObject):
 
         if id_or_name:
             query = query.filter(
-                or_(cls.id == id_or_name, cls.name == id_or_name)
+                or_(cls.id == id_or_name, cls.content == id_or_name)
             )
 
         if q:
             query = query.filter(
-                or_(cls.name.contains(q), cls.name.ilike(r"%{}%".format(q)))
+                or_(cls.content.contains(q),
+                    cls.content.ilike(r"%{}%".format(q)))
             )
 
         if order_by:
@@ -94,6 +95,18 @@ kwh_data_table = Table(
         types.UnicodeText,
         ForeignKey('user.id', ondelete='CASCADE'),
         nullable=False),
+    Column(
+        'theme',
+        types.UnicodeText,
+        ForeignKey('theme.id', ondelete='CASCADE')),
+    Column(
+        'sub_theme',
+        types.UnicodeText,
+        ForeignKey('sub_themes.id', ondelete='CASCADE')),
+    Column(
+        'rq',
+        types.UnicodeText,
+        ForeignKey('research_question.id', ondelete='CASCADE')),
     Column(
         'created_at',
         types.DateTime,

--- a/ckanext/knowledgehub/model/kwh_data.py
+++ b/ckanext/knowledgehub/model/kwh_data.py
@@ -93,8 +93,7 @@ kwh_data_table = Table(
     Column(
         'user',
         types.UnicodeText,
-        ForeignKey('user.id', ondelete='CASCADE'),
-        nullable=False),
+        ForeignKey('user.id', ondelete='CASCADE')),
     Column(
         'theme',
         types.UnicodeText,

--- a/ckanext/knowledgehub/model/kwh_data.py
+++ b/ckanext/knowledgehub/model/kwh_data.py
@@ -1,0 +1,112 @@
+import datetime
+
+import ckan.logic as logic
+from ckan import model
+from ckan.model.meta import metadata, mapper, Session
+from ckan.model.types import make_uuid
+from ckan.model.domain_object import DomainObject
+
+from sqlalchemy import types, ForeignKey, Column, Table, desc, asc, or_
+
+__all__ = [
+    'KWHData',
+    'kwh_data_table',
+    'setup'
+]
+
+kwh_data_table = None
+
+
+class KWHData(DomainObject):
+
+    @classmethod
+    def get(cls, id_or_name=None, **kwargs):
+        q = kwargs.get('q')
+        limit = kwargs.get('limit')
+        offset = kwargs.get('offset')
+        order_by = kwargs.get('order_by')
+
+        kwargs.pop('q', None)
+        kwargs.pop('limit', None)
+        kwargs.pop('offset', None)
+        kwargs.pop('order_by', None)
+
+        query = Session.query(cls).autoflush(False)
+        query = query.filter_by(**kwargs)
+
+        if id_or_name:
+            query = query.filter(
+                or_(cls.id == id_or_name, cls.name == id_or_name)
+            )
+
+        if q:
+            query = query.filter(
+                or_(cls.name.contains(q), cls.name.ilike(r"%{}%".format(q)))
+            )
+
+        if order_by:
+            query = query.order_by(order_by)
+
+        if limit:
+            query = query.limit(limit)
+
+        if offset:
+            query = query.offset(offset)
+
+        return query
+
+    @classmethod
+    def update(cls, filter, data):
+        obj = Session.query(cls).filter_by(**filter)
+        obj.update(data)
+        Session.commit()
+
+        return obj.first()
+
+    @classmethod
+    def delete(cls, filter):
+        obj = Session.query(cls).filter_by(**filter).first()
+        if obj:
+            Session.delete(obj)
+            Session.commit()
+        else:
+            raise logic.NotFound
+
+
+kwh_data_table = Table(
+    'kwh_data',
+    metadata,
+    Column(
+        'id',
+        types.UnicodeText,
+        primary_key=True,
+        default=make_uuid),
+    Column(
+        'type',
+        types.UnicodeText,
+        nullable=False),
+    Column(
+        'content',
+        types.UnicodeText,
+        nullable=False),
+    Column(
+        'user',
+        types.UnicodeText,
+        ForeignKey('user.id', ondelete='CASCADE'),
+        nullable=False),
+    Column(
+        'created_at',
+        types.DateTime,
+        default=datetime.datetime.utcnow,
+        onupdate=datetime.datetime.utcnow)
+)
+
+
+mapper(
+    KWHData,
+    kwh_data_table,
+)
+
+
+def setup():
+    metadata.create_all(model.meta.engine)

--- a/ckanext/knowledgehub/model/rnn_corpus.py
+++ b/ckanext/knowledgehub/model/rnn_corpus.py
@@ -1,0 +1,104 @@
+import datetime
+
+import ckan.logic as logic
+from ckan import model
+from ckan.model.meta import metadata, mapper, Session
+from ckan.model.types import make_uuid
+from ckan.model.domain_object import DomainObject
+
+from sqlalchemy import types, ForeignKey, Column, Table, desc, asc, or_
+
+__all__ = [
+    'RNNCorpus',
+    'rnn_corpus_table',
+    'setup'
+]
+
+rnn_corpus_table = None
+
+
+class RNNCorpus(DomainObject):
+
+    @classmethod
+    def get(cls, id_or_name=None, **kwargs):
+        q = kwargs.get('q')
+        limit = kwargs.get('limit')
+        offset = kwargs.get('offset')
+        order_by = kwargs.get('order_by')
+
+        kwargs.pop('q', None)
+        kwargs.pop('limit', None)
+        kwargs.pop('offset', None)
+        kwargs.pop('order_by', None)
+
+        query = Session.query(cls).autoflush(False)
+        query = query.filter_by(**kwargs)
+
+        if id_or_name:
+            query = query.filter(
+                or_(cls.id == id_or_name, cls.content == id_or_name)
+            )
+
+        if q:
+            query = query.filter(
+                or_(cls.content.contains(q),
+                    cls.content.ilike(r"%{}%".format(q)))
+            )
+
+        if order_by:
+            query = query.order_by(order_by)
+
+        if limit:
+            query = query.limit(limit)
+
+        if offset:
+            query = query.offset(offset)
+
+        return query
+
+    @classmethod
+    def update(cls, filter, data):
+        obj = Session.query(cls).filter_by(**filter)
+        obj.update(data)
+        Session.commit()
+
+        return obj.first()
+
+    @classmethod
+    def delete(cls, filter):
+        obj = Session.query(cls).filter_by(**filter).first()
+        if obj:
+            Session.delete(obj)
+            Session.commit()
+        else:
+            raise logic.NotFound
+
+
+rnn_corpus_table = Table(
+    'kwh_data',
+    metadata,
+    Column(
+        'id',
+        types.UnicodeText,
+        primary_key=True,
+        default=make_uuid),
+    Column(
+        'corpus',
+        types.UnicodeText,
+        nullable=False),
+    Column(
+        'created_at',
+        types.DateTime,
+        default=datetime.datetime.utcnow,
+        onupdate=datetime.datetime.utcnow)
+)
+
+
+mapper(
+    RNNCorpus,
+    rnn_corpus_table,
+)
+
+
+def setup():
+    metadata.create_all(model.meta.engine)

--- a/ckanext/knowledgehub/model/rnn_corpus.py
+++ b/ckanext/knowledgehub/model/rnn_corpus.py
@@ -75,7 +75,7 @@ class RNNCorpus(DomainObject):
 
 
 rnn_corpus_table = Table(
-    'kwh_data',
+    'rnn_corpus',
     metadata,
     Column(
         'id',

--- a/ckanext/knowledgehub/plugin.py
+++ b/ckanext/knowledgehub/plugin.py
@@ -1,3 +1,5 @@
+from routes.mapper import SubMapper
+
 import ckan.plugins as plugins
 import ckan.plugins.toolkit as toolkit
 from ckan import logic
@@ -166,6 +168,13 @@ class KnowledgehubPlugin(plugins.SingletonPlugin, DefaultDatasetForm):
     def before_map(self, map):
         map.redirect('/', '/dataset',
                      _redirect_code='301 Moved Permanently')
+        # Override the package search action.
+        with SubMapper(
+            map,
+            controller='ckanext.knowledgehub.controllers:KWHPackageController'
+        ) as m:
+            m.connect('search', '/dataset', action='search')
+
         return map
 
     # IPackageController

--- a/ckanext/knowledgehub/plugin.py
+++ b/ckanext/knowledgehub/plugin.py
@@ -6,8 +6,11 @@ from ckan import logic
 from ckan.lib.plugins import DefaultDatasetForm
 
 import ckanext.knowledgehub.helpers as h
+from ckanext.knowledgehub.rnn import worker as kwh_data_worker
 
 from ckanext.knowledgehub.helpers import _register_blueprints
+
+toolkit.enqueue_job(kwh_data_worker.learn, title=u'Predictive search', queue=u'predictive-search')
 
 
 class KnowledgehubPlugin(plugins.SingletonPlugin, DefaultDatasetForm):

--- a/ckanext/knowledgehub/rnn/helpers.py
+++ b/ckanext/knowledgehub/rnn/helpers.py
@@ -1,0 +1,63 @@
+import logging
+
+from ckan.plugins import toolkit
+from ckan import logic
+
+
+log = logging.getLogger(__name__)
+
+
+def get_kwh_data():
+	corpus = ''
+	try:
+		kwh_data = toolkit.get_action('kwh_data_list')({}, {})
+	except Exception as e:
+		log.debug('Error while loading KnowledgeHub data: %s' % str(e))
+		return corpus
+
+	if kwh_data.get('total'):
+		data = kwh_data.get('data', [])
+		for entry in data:
+			corpus += ' %s' % entry.get('content')
+
+	return corpus
+
+
+def prepare_input(text):
+    x = np.zeros((1, SEQUENCE_LENGTH, len(chars)))
+    for t, char in enumerate(text):
+        x[0, t, char_indices[char]] = 1.
+
+    return x
+
+
+def sample(preds, top_n=3):
+    preds = np.asarray(preds).astype('float64')
+    preds = np.log(preds)
+    exp_preds = np.exp(preds)
+    preds = exp_preds / np.sum(exp_preds)
+
+    return heapq.nlargest(top_n, range(len(preds)), preds.take)
+
+
+def predict_completion(text):
+    original_text = text
+    generated = text
+    completion = ''
+    while True:
+        x = prepare_input(text)
+        preds = model.predict(x, verbose=0)[0]
+        next_index = sample(preds, top_n=1)[0]
+        next_char = indices_char[next_index]
+        text = text[1:] + next_char
+        completion += next_char
+
+        if len(original_text + completion) + 2 > len(original_text) and next_char == ' ':
+            return completion
+
+
+def predict_completions(text, n=3):
+    x = prepare_input(text)
+    preds = model.predict(x, verbose=0)[0]
+    next_indices = sample(preds, n)
+    return [indices_char[idx] + predict_completion(text[1:] + indices_char[idx]) for idx in next_indices]

--- a/ckanext/knowledgehub/rnn/helpers.py
+++ b/ckanext/knowledgehub/rnn/helpers.py
@@ -24,7 +24,7 @@ def prepare_rnn_corpus(corpus):
 
 def prepare_input(text, unique_chars, char_indices):
     sequence_length = int(
-        config.get(u'ckanext.knowledgehub.rnn.sequence_length', 15)
+        config.get(u'ckanext.knowledgehub.rnn.sequence_length', 10)
     )
     x = np.zeros((1, sequence_length, len(unique_chars)))
     for t, char in enumerate(text):
@@ -77,7 +77,7 @@ def predict_completions(text):
         return []
 
     sequence_length = int(
-        config.get(u'ckanext.knowledgehub.rnn.sequence_length', 15)
+        config.get(u'ckanext.knowledgehub.rnn.sequence_length', 10)
     )
     if sequence_length > len(text):
         return []

--- a/ckanext/knowledgehub/rnn/helpers.py
+++ b/ckanext/knowledgehub/rnn/helpers.py
@@ -1,30 +1,47 @@
 import logging
+import os
+
+import heapq
+import numpy as np
+from keras.models import load_model
 
 from ckan.plugins import toolkit
 from ckan import logic
+from ckan.common import config
 
 
 log = logging.getLogger(__name__)
 
 
 def get_kwh_data():
-	corpus = ''
-	try:
-		kwh_data = toolkit.get_action('kwh_data_list')({}, {})
-	except Exception as e:
-		log.debug('Error while loading KnowledgeHub data: %s' % str(e))
-		return corpus
+    corpus = ''
+    try:
+        kwh_data = toolkit.get_action('kwh_data_list')({}, {})
+    except Exception as e:
+        log.debug('Error while loading KnowledgeHub data: %s' % str(e))
+        return corpus
 
-	if kwh_data.get('total'):
-		data = kwh_data.get('data', [])
-		for entry in data:
-			corpus += ' %s' % entry.get('content')
+    if kwh_data.get('total'):
+        data = kwh_data.get('data', [])
+        for entry in data:
+            corpus += ' %s' % entry.get('content')
 
-	return corpus
+    return corpus
 
 
-def prepare_input(text):
-    x = np.zeros((1, SEQUENCE_LENGTH, len(chars)))
+def prepare_rnn_corpus(corpus):
+    chars = sorted(list(set(corpus)))
+    char_indices = dict((c, i) for i, c in enumerate(chars))
+    indices_char = dict((i, c) for i, c in enumerate(chars))
+
+    return chars, char_indices, indices_char
+
+
+def prepare_input(text, chars, char_indices):
+    sequence_length = int(
+        config.get(u'ckanext.knowledgehub.rnn.sequence_length', 10)
+    )
+    x = np.zeros((1, sequence_length, len(chars)))
     for t, char in enumerate(text):
         x[0, t, char_indices[char]] = 1.
 
@@ -40,24 +57,46 @@ def sample(preds, top_n=3):
     return heapq.nlargest(top_n, range(len(preds)), preds.take)
 
 
-def predict_completion(text):
+def predict_completion(model, text, chars, char_indices, indices_char):
     original_text = text
     generated = text
     completion = ''
     while True:
-        x = prepare_input(text)
+        x = prepare_input(text, chars, char_indices)
         preds = model.predict(x, verbose=0)[0]
         next_index = sample(preds, top_n=1)[0]
         next_char = indices_char[next_index]
         text = text[1:] + next_char
         completion += next_char
 
-        if len(original_text + completion) + 2 > len(original_text) and next_char == ' ':
+        if (len(original_text + completion) + 2 > len(original_text) and
+                next_char == ' '):
+
             return completion
 
 
 def predict_completions(text, n=3):
-    x = prepare_input(text)
+    c = toolkit.get_action('get_last_rnn_corpus')({}, {})
+    chars, char_indices, indices_char = prepare_rnn_corpus(c)
+
+    model_path = config.get(
+        u'ckanext.knowledgehub.rnn.model',
+        './keras_model.h5'
+    )
+    if not os.path.isfile(model_path):
+        log.debug('Error: RNN model does not exist!')
+        return []
+
+    model = load_model(model_path)
+    x = prepare_input(text, chars, char_indices)
     preds = model.predict(x, verbose=0)[0]
     next_indices = sample(preds, n)
-    return [indices_char[idx] + predict_completion(text[1:] + indices_char[idx]) for idx in next_indices]
+    return [
+        indices_char[idx] +
+        predict_completion(
+            model,
+            text[1:] + indices_char[idx],
+            chars,
+            char_indices,
+            indices_char
+        ) for idx in next_indices]

--- a/ckanext/knowledgehub/rnn/helpers.py
+++ b/ckanext/knowledgehub/rnn/helpers.py
@@ -4,7 +4,6 @@ import os
 import heapq
 import numpy as np
 import tensorflow as tf
-from keras import backend as K
 from keras.models import load_model
 
 from ckan.plugins import toolkit
@@ -115,6 +114,3 @@ def predict_completions(text):
     except Exception as e:
         log.debug('Error while prediction: %s' % str(e))
         return []
-    finally:
-        # always clean previous session
-        K.clear_session()

--- a/ckanext/knowledgehub/rnn/worker.py
+++ b/ckanext/knowledgehub/rnn/worker.py
@@ -42,7 +42,7 @@ def learn():
         return
 
     sequence_length = int(
-        config.get(u'ckanext.knowledgehub.rnn.sequence_length', 15)
+        config.get(u'ckanext.knowledgehub.rnn.sequence_length', 10)
     )
     if len(data) <= sequence_length:
         return

--- a/ckanext/knowledgehub/rnn/worker.py
+++ b/ckanext/knowledgehub/rnn/worker.py
@@ -35,6 +35,12 @@ def learn():
     unique_chars, char_indices, indices_char = rnn_h.prepare_rnn_corpus(data)
     log.info('unique chars: %d' % len(unique_chars))
 
+    min_length_corpus = int(
+        config.get(u'ckanext.knowledgehub.rnn.min_length_corpus', 300)
+    )
+    if min_length_corpus > len(data):
+        return
+
     sequence_length = int(
         config.get(u'ckanext.knowledgehub.rnn.sequence_length', 15)
     )

--- a/ckanext/knowledgehub/rnn/worker.py
+++ b/ckanext/knowledgehub/rnn/worker.py
@@ -1,0 +1,125 @@
+import os
+import logging
+import pickle
+
+import numpy as np
+np.random.seed(42)
+
+import tensorflow as tf
+tf.set_random_seed(42)
+
+from keras.models import Sequential, load_model
+from keras.layers import Dense, Activation
+from keras.layers import LSTM, Dropout
+from keras.layers import TimeDistributed
+from keras.layers.core import Dense, Activation, Dropout, RepeatVector
+from keras.optimizers import RMSprop
+from keras.callbacks import EarlyStopping
+
+from ckan.common import config
+
+from ckanext.knowledgehub.rnn import helpers as rnn_helper
+
+
+log = logging.getLogger(__name__)
+
+
+def learn():
+    try:
+        data = rnn_helper.get_kwh_data()
+    except Exception as e:
+        log.debug('Error while training the model: %s' % str(e))
+
+    chars = sorted(list(set(data)))
+    char_indices = dict((c, i) for i, c in enumerate(chars))
+    indices_char = dict((i, c) for i, c in enumerate(chars))
+
+    log.info('unique chars: %d' % len(chars))
+
+    sequence_length = int(config.get(u'ckanext.knowledgehub.rnn.sequence_length', 10))
+    if len(data) <= sequence_length:
+        return
+
+    step = int(config.get(u'ckanext.knowledgehub.rnn.sentence_step', 3))
+    sentences = []
+    next_chars = []
+    for i in range(0, len(data) - sequence_length, step):
+        sentences.append(data[i: i + sequence_length])
+        next_chars.append(data[i + sequence_length])
+
+    log.info('num training examples: %d ' % len(sentences))
+
+    X = np.zeros((len(sentences), sequence_length, len(chars)), dtype=np.bool)
+    y = np.zeros((len(sentences), len(chars)), dtype=np.bool)
+    for i, sentence in enumerate(sentences):
+        for t, char in enumerate(sentence):
+            X[i, t, char_indices[char]] = 1
+        y[i, char_indices[next_chars[i]]] = 1
+
+    history = ''
+    try:
+        model = Sequential()
+        model.add(LSTM(128, input_shape=(sequence_length, len(chars))))
+        model.add(Dense(len(chars)))
+        model.add(Activation('softmax'))
+
+        optimizer = RMSprop(lr=0.01)
+        model.compile(
+            loss='categorical_crossentropy',
+            optimizer=optimizer,
+            metrics=['accuracy'])
+
+        callbacks = [
+            EarlyStopping(
+                monitor='val_loss',
+                min_delta=0.01,
+                patience=3,
+                verbose=1,
+                mode='auto',
+                baseline=None,
+                restore_best_weights=False
+            )
+        ]
+        history = model.fit(
+            X,
+            y,
+            validation_split=0.05,
+            batch_size=128,
+            epochs=int(config.get(u'ckanext.knowledgehub.rnn.max_epochs', 50)),
+            shuffle=True,
+            callbacks=callbacks
+        ).history
+    except Exception as e:
+        log.debug('Error while creating RNN model: %s' % str(e))
+        return
+
+    model_path = config.get(u'ckanext.knowledgehub.rnn.model', './keras_model.h5')
+    model_dir = os.path.dirname(model_path)
+    if not os.path.exists(model_dir):
+        try:
+            os.makedirs(model_dir)
+        except Exception as e:
+            log.debug('Error while creating RNN model DIR: %s' % str(e))
+            return
+
+    try:
+        model.save(model_path)
+    except Exception as e:
+        log.debug('Error while saving RNN model: %s' % str(e))
+        return
+
+    history_path = config.get(u'ckanext.knowledgehub.rnn.history', './history.p')
+    history_dir = os.path.dirname(history_path)
+    if not os.path.exists(history_dir):
+        try:
+            os.makedirs(history_dir)
+        except Exception as e:
+            log.debug('Error while creating RNN history DIR: %s' % str(e))
+            return
+
+    try:
+        pickle.dump(history, open(history_path, "wb"))
+    except Exception as e:
+        log.debug('Error while saving RNN history: %s' % str(e))
+        return
+

--- a/ckanext/knowledgehub/rnn/worker.py
+++ b/ckanext/knowledgehub/rnn/worker.py
@@ -1,6 +1,7 @@
 import os
 import logging
 import pickle
+import time
 
 import numpy as np
 import tensorflow as tf
@@ -40,12 +41,18 @@ def learn():
         config.get(u'ckanext.knowledgehub.rnn.min_length_corpus', 300)
     )
     if min_length_corpus > len(data):
+        log.info(
+            'The minimum length of the corpus is %s, current corpus has %d'
+            % (min_length_corpus, len(data)))
         return
 
     sequence_length = int(
         config.get(u'ckanext.knowledgehub.rnn.sequence_length', 10)
     )
     if len(data) <= sequence_length:
+        log.info(
+            'The length of the RNN sequence %d, given %d'
+            % (sequence_length, len(data)))
         return
 
     step = int(config.get(u'ckanext.knowledgehub.rnn.sentence_step', 3))

--- a/ckanext/knowledgehub/rnn/worker.py
+++ b/ckanext/knowledgehub/rnn/worker.py
@@ -152,7 +152,7 @@ def learn():
 
         lock_model_path = '%s.lock' % model_path
         lock = FileLock(lock_model_path)
-        with lock.acquire(timeout=10):
+        with lock.acquire(timeout=1000):
             if os.path.exists(model_path):
                 os.remove(model_path)
             os.rename(train_module_path, model_path)

--- a/ckanext/knowledgehub/templates/snippets/search_form.html
+++ b/ckanext/knowledgehub/templates/snippets/search_form.html
@@ -1,0 +1,16 @@
+{% resource 'knowledgehub/javascript/search_prediction.js' %}
+
+{% ckan_extends %}
+
+{% block search_input %}
+  <div class="input-group search-input-group">
+    <input aria-label="{% block header_site_search_label %}{{ placeholder }}{% endblock %}" id="field-giant-search" type="text" class="form-control input-lg" name="q" value="{{ query }}" autocomplete="off" placeholder="{{ 'OK' }}">
+    {% block search_input_button %}
+    <span class="input-group-btn">
+      <button class="btn btn-default btn-lg" type="submit" value="search">
+        <i class="fa fa-search"></i>
+      </button>
+    </span>
+    {% endblock %}
+  </div>
+{% endblock %}

--- a/ckanext/knowledgehub/templates/snippets/search_form.html
+++ b/ckanext/knowledgehub/templates/snippets/search_form.html
@@ -4,7 +4,7 @@
 
 {% block search_input %}
   <div class="input-group search-input-group">
-    <input aria-label="{% block header_site_search_label %}{{ placeholder }}{% endblock %}" id="field-giant-search" type="text" class="form-control input-lg" name="q" value="{{ query }}" autocomplete="off" placeholder="{{ 'OK' }}">
+    <input aria-label="{% block header_site_search_label %}{{ placeholder }}{% endblock %}" id="field-giant-search" type="text" class="form-control input-lg" name="q" value="{{ query }}" autocomplete="off" placeholder="{{ placeholder }}">
     {% block search_input_button %}
     <span class="input-group-btn">
       <button class="btn btn-default btn-lg" type="submit" value="search">

--- a/ckanext/knowledgehub/views/research_question.py
+++ b/ckanext/knowledgehub/views/research_question.py
@@ -265,6 +265,18 @@ class CreateView(MethodView):
             error_summary = e.error_summary
             return self.get(data_dict, errors, error_summary)
 
+        try:
+            kwh_data = {
+                'type': 'rq',
+                'content': research_question.get('title'),
+                'rq': research_question.get('id')
+            }
+            logic.get_action(u'kwh_data_create')(
+                context, kwh_data
+            )
+        except Exception as e:
+            log.debug('Error while storing KWH data: %s' % str(e))
+
         return h.redirect_to(
             u'research_question.read',
             name=research_question.get(u'name'))
@@ -422,6 +434,19 @@ class EditView(MethodView):
             errors = e.error_dict
             error_summary = e.error_summary
             return self.get(name, data_dict, errors, error_summary)
+
+        try:
+            old_rq = context['research_question']
+            kwh_data = {
+                'type': 'rq',
+                'old_content': old_rq.get('title'),
+                'new_content': research_question.get('title')
+            }
+            logic.get_action(u'kwh_data_update')(
+                context, kwh_data
+            )
+        except Exception as e:
+            log.debug('Error while storing KWH data: %s' % str(e))
 
         return h.redirect_to(u'research_question.read',
                              name=research_question.get(u'name'))

--- a/ckanext/knowledgehub/views/sub_theme.py
+++ b/ckanext/knowledgehub/views/sub_theme.py
@@ -207,9 +207,10 @@ class CreateView(MethodView):
         try:
             kwh_data = {
                 'type': 'sub-theme',
-                'content': sub_theme.get('title')
+                'content': sub_theme.get('title'),
+                'sub_theme': sub_theme.get('id')
             }
-            logic.get_action(u'kwh_data')(
+            logic.get_action(u'kwh_data_create')(
                 context, kwh_data
             )
         except Exception as e:
@@ -291,7 +292,7 @@ class EditView(MethodView):
         data_dict['id'] = sub_theme.get('id')
 
         try:
-            sub_theme = logic.get_action(u'sub_theme_update')(
+            st = logic.get_action(u'sub_theme_update')(
                 context, data_dict
             )
             h.flash_notice(_(u'Sub-Theme has been updated.'))
@@ -305,9 +306,10 @@ class EditView(MethodView):
         try:
             kwh_data = {
                 'type': 'sub-theme',
-                'content': sub_theme.get('title')
+                'old_content': sub_theme.get('title'),
+                'new_content': st.get('title')
             }
-            logic.get_action(u'kwh_data')(
+            logic.get_action(u'kwh_data_update')(
                 context, kwh_data
             )
         except Exception as e:

--- a/ckanext/knowledgehub/views/sub_theme.py
+++ b/ckanext/knowledgehub/views/sub_theme.py
@@ -204,6 +204,17 @@ class CreateView(MethodView):
             error_summary = e.error_summary
             return self.get(data_dict, errors, error_summary)
 
+        try:
+            kwh_data = {
+                'type': 'sub-theme',
+                'content': sub_theme.get('title')
+            }
+            logic.get_action(u'kwh_data')(
+                context, kwh_data
+            )
+        except Exception as e:
+            log.debug('Error while storing KWH data: %s' % str(e))
+
         return h.redirect_to(u'sub_theme.read', name=sub_theme.get(u'name'))
 
 
@@ -290,6 +301,17 @@ class EditView(MethodView):
             errors = e.error_dict
             error_summary = e.error_summary
             return self.get(name, data_dict, errors, error_summary)
+
+        try:
+            kwh_data = {
+                'type': 'sub-theme',
+                'content': sub_theme.get('title')
+            }
+            logic.get_action(u'kwh_data')(
+                context, kwh_data
+            )
+        except Exception as e:
+            log.debug('Error while storing KWH data: %s' % str(e))
 
         return h.redirect_to(u'sub_theme.read', name=sub_theme.get(u'name'))
 

--- a/ckanext/knowledgehub/views/theme.py
+++ b/ckanext/knowledgehub/views/theme.py
@@ -189,6 +189,18 @@ class CreateView(MethodView):
                             errors,
                             error_summary)
 
+        try:
+            kwh_data = {
+                'type': 'theme',
+                'content': theme.get('title'),
+                'theme': theme.get('id')
+            }
+            logic.get_action(u'kwh_data_create')(
+                context, kwh_data
+            )
+        except Exception as e:
+            log.debug('Error while storing KWH data: %s' % str(e))
+
         return h.redirect_to(u'theme.read',
                              name=theme['name'])
 
@@ -206,6 +218,7 @@ class EditView(MethodView):
                 context, data_dict)
             check_access(u'theme_update', context)
             context['id'] = theme['id']
+            context['old_theme'] = theme
         except NotAuthorized:
             return base.abort(403, _(u'Unauthorized'
                                      u' to update theme'))
@@ -259,6 +272,20 @@ class EditView(MethodView):
             error_summary = e.error_summary
             return self.get(name, data_dict,
                             errors, error_summary)
+
+        try:
+            old_theme = context.get('old_theme')
+            kwh_data = {
+                'type': 'theme',
+                'old_content': old_theme.get('title'),
+                'new_content': theme.get('title')
+            }
+            logic.get_action(u'kwh_data_update')(
+                context, kwh_data
+            )
+        except Exception as e:
+            print str(e)
+            log.debug('Error while storing KWH data: %s' % str(e))
 
         return h.redirect_to(u'theme.read', name=theme['name'])
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ functools32==3.2.3.post2
 tensorflow==1.13.1
 keras==2.2.4
 h5py==2.9.0
+filelock==3.0.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,5 @@
 pymssql==2.1.4
 functools32==3.2.3.post2
+tensorflow==1.13.1
+keras==2.2.4
+h5py==2.9.0


### PR DESCRIPTION
Add predictions to home page search. 

To run:
1. Install the requirements first
2. Init the tables
3. Create new themes, sub-themes, RQs with total length more that 300 chars
4. Run the background job for predictive search, see README
5. Then, after 10 chars typed in the search the suggestions will be shown.