### PR TITLE
Dashboard links

### DIFF
--- a/ckanext/knowledgehub/templates/package/search.html
+++ b/ckanext/knowledgehub/templates/package/search.html
@@ -58,9 +58,11 @@
                 <div class="row">
                     <div class="col-lg-3 group-list secondary dashboards">
                         <h4>DASHBOARDS</h4>
+                        {% set found_dashboards = h.get_dashboards(limit=4, order_by='created_at desc') %}
                         <hr>
                         <ul class="list-unstyled nav nav-simple">
-                            {% for dashboard in h.get_dashboards(limit=4, order_by='created_at desc') %}
+                            {% if found_dashboards %}
+                            {% for dashboard in found_dashboards %}
                             <li class="nav-item">
                                 <a class="dashboard-link"
                                     href="{{  h.url_for('dashboards.view', name=dashboard.name) }}">
@@ -79,7 +81,23 @@
                                 </a>
                             </li>
                             {% endfor %}
+                            {% else %}
+                            <li class="nav-item">
+                                <div>
+                                    {{_('No Dashboards have been created.')}}
+                                    <span class="btn btn-link">
+                                        {{ h.nav_link(_('Create new Dashboard now'), named_route='dashboards.new', icon='angle-double-right') }}
+                                    </span>
+                                </div>
+                            </li>
+                            {% endif %}
                         </ul>
+                        {% if found_dashboards %}
+                        <div class="btn btn-link">
+                            {{ h.nav_link(_('View All Dashboards'), named_route='dashboards.index', icon='angle-double-right') }}
+                        </div>
+                        {% endif %}
+
                         {% block secondary_content %}
                         <div class="filters">
                             <div>
@@ -89,11 +107,6 @@
                             </div>
                             <a class="close no-text hide-filters"><i class="fa fa-times-circle"></i><span
                                     class="text">close</span></a>
-                        </div>
-                        {% endblock %}
-                        {% block dashboards_footer %}
-                        <div class="btn btn-link">
-                            {{ h.nav_link(_('View All Dashboards'), named_route='dashboards.index', icon='angle-double-right') }}
                         </div>
                         {% endblock %}
                     </div>

--- a/ckanext/knowledgehub/templates/package/search.html
+++ b/ckanext/knowledgehub/templates/package/search.html
@@ -91,6 +91,11 @@
                                     class="text">close</span></a>
                         </div>
                         {% endblock %}
+                        {% block dashboards_footer %}
+                        <div class="btn btn-link">
+                            {{ h.nav_link(_('View All Dashboards'), named_route='dashboards.index', icon='angle-double-right') }}
+                        </div>
+                        {% endblock %}
                     </div>
                     <div class="col-lg-9 group-list indicators">
                         <div class="group-list-items">


### PR DESCRIPTION
Adds links to "View all dashboards" and "create new dashboard" on the left Dashboards pane in the search page.

@NikolaLekic Please review the styling of the elements (links/buttons) and update if necessary.
@vladoohr confirm the wording is correct.