### PR TITLE
Unifing the /Edit breadcrumb and Organizations -> Functional Units.

### DIFF
--- a/ckanext/knowledgehub/templates/group/edit.html
+++ b/ckanext/knowledgehub/templates/group/edit.html
@@ -5,6 +5,6 @@
   <li>{% link_for _('Joint Analysis'), controller='group', action='index' %}</li>
   {% block breadcrumb_content_inner %}
     <li>{% link_for group.display_name|truncate(35), controller='group', action='read', id=group.name %}</li>
-    <li class="active">{% link_for _('Manage'), controller='group', action='edit', id=group.name %}</li>
+    <li class="active">{% link_for _('Edit'), controller='group', action='edit', id=group.name %}</li>
   {% endblock %}
 {% endblock %}

--- a/ckanext/knowledgehub/templates/organization/edit_base.html
+++ b/ckanext/knowledgehub/templates/organization/edit_base.html
@@ -6,6 +6,6 @@
   <li>{% link_for _('Functional Units'), controller='organization', action='index', named_route=group_type + '_index' %}</li>
   {% block breadcrumb_content_inner %}
     <li>{% link_for organization.display_name|truncate(35), controller='organization', action='read', id=organization.name, named_route=group_type + '_read' %}</li>
-    <li class="active">{% link_for _('Manage'), controller='organization', action='edit', id=organization.name, named_route=group_type + '_edit' %}</li>
+    <li class="active">{% link_for _('Edit'), controller='organization', action='edit', id=organization.name, named_route=group_type + '_edit' %}</li>
   {% endblock %}
 {% endblock %}

--- a/ckanext/knowledgehub/templates/package/edit_view.html
+++ b/ckanext/knowledgehub/templates/package/edit_view.html
@@ -6,7 +6,7 @@
   {% if pkg.organization %}
     {% set organization = h.get_translated(pkg.organization, 'title') or pkg.organization.name %}
     {% set group_type = pkg.organization.type %}
-    <li>{% link_for _('Organizations'), controller='organization', action='index', named_route=group_type + '_index' %}</li>
+    <li>{% link_for _('Functional Units'), controller='organization', action='index', named_route=group_type + '_index' %}</li>
     <li>{% link_for organization|truncate(30), controller='organization', action='read', id=pkg.organization.name, named_route=group_type + '_read' %}</li>
   {% else %}
     <li>{% link_for _('Datasets'), controller='package', action='search' %}</li>
@@ -21,5 +21,4 @@
   <li>{% link_for _(resource_view.title)|truncate(30), controller='package', action='resource_read', id=pkg.name, resource_id=res.id, view_id=resource_view.id %}</li>
   <li{% block breadcrumb_edit_selected %} class="active"{% endblock %}><a href="">{{ _('Edit') }}</a></li>
   {% endif %}
-  <h2>PAJO</h2>
 {% endblock %}

--- a/ckanext/knowledgehub/templates/research_question/edit.html
+++ b/ckanext/knowledgehub/templates/research_question/edit.html
@@ -4,7 +4,7 @@
 <li>{{ h.nav_link(_('Research questions'), named_route='research_question.search') }}</li>
 <li>{{ h.nav_link(rq.title|truncate(30), named_route='research_question.read', name=rq.name) }}</li>
 
-<li class="active">{{ h.nav_link(_('Manage'), named_route='research_question.edit', name=rq.name) }}</li>
+<li class="active">{{ h.nav_link(_('Edit'), named_route='research_question.edit', name=rq.name) }}</li>
 {% endblock %}
 
 {% block page_header %}{% endblock %}

--- a/ckanext/knowledgehub/templates/sub_theme/edit.html
+++ b/ckanext/knowledgehub/templates/sub_theme/edit.html
@@ -2,8 +2,8 @@
 
 {% block breadcrumb_content %}
   <li>{{ h.nav_link(_('Sub-Themes'), named_route='sub_theme.search') }}</li>
-  <li>{{ h.nav_link(sub_theme.get('name', ''), named_route='sub_theme.read', name=sub_theme.get('name', '')) }}</li>
-  <li class="active">{{ h.nav_link(_('Manage'), named_route='sub_theme.edit', name=sub_theme.get('name', '')) }}</li>
+  <li>{{ h.nav_link(sub_theme.get('title', sub_theme.get('name', ''))|truncate(35), named_route='sub_theme.read', name=sub_theme.get('name', '')) }}</li>
+  <li class="active">{{ h.nav_link(_('Edit'), named_route='sub_theme.edit', name=sub_theme.get('name', '')) }}</li>
 {% endblock %}
 
 


### PR DESCRIPTION
Fixes labels that I've noticed to be not unified or wrong.