### PR TITLE
Fixes error 500 on dataset pages due to bad Solr index search.

### DIFF
--- a/ckanext/knowledgehub/lib/search.py
+++ b/ckanext/knowledgehub/lib/search.py
@@ -1,0 +1,65 @@
+''' Contains overrides for CKAN search index functionality to support multiple
+entity types: package, dashboard, visualization etc.
+'''
+
+from ckan.lib.search.query import PackageSearchQuery
+from ckan.lib.search.common import make_connection, SearchError
+from ckan.common import config
+import pysolr
+import logging
+
+log = logging.getLogger(__name__)
+
+
+class KnowledgeHubPackageSearchQuery(PackageSearchQuery):
+
+    def get_index(self, reference):
+        query = {
+            'rows': 1,
+            'q': 'name:"%s" OR id:"%s"' % (reference, reference),
+            'wt': 'json',
+            'fq': [
+                    'site_id:"%s"' % config.get('ckan.site_id'),
+                    'entity_type:package'
+            ],
+        }
+
+        try:
+            if query['q'].startswith('{!'):
+                raise SearchError('Local parameters are not supported.')
+        except KeyError:
+            pass
+
+        conn = make_connection(decode_dates=False)
+        log.debug('Package query: %r' % query)
+        try:
+            solr_response = conn.search(**query)
+        except pysolr.SolrError as e:
+            raise SearchError('SOLR returned an error running '
+                              'query: %r Error: %r' %
+                              (query, e))
+
+        if solr_response.hits == 0:
+            raise SearchError('Dataset not found in '
+                              'the search index: %s' % reference)
+        else:
+            return solr_response.docs[0]
+
+
+def patch_ckan_core_search():
+    '''Patches CKAN's core search funtionality to add fq='entity_type:package'
+    when searching for packages in Solr.
+    With KnowledgeHub extension, Solr is extended to support multiple types of
+    entities for indexing, so we must take into account the entity_type when
+    doing index searches.
+    '''
+    import ckan.lib.search as ckan_search
+    if not hasattr(ckan_search, '_QUERIES'):
+        raise Exception('Cannot patch CKAN query search: Unable to register '
+                        'custom PackageSearchQuery to CKAN search query '
+                        'mechanism. The _QUERIES global in ckan.lib.search '
+                        'was not found, which means that this patch will not'
+                        'work on your curren CKAN version.')
+
+    ckan_search._QUERIES['package'] = KnowledgeHubPackageSearchQuery
+    log.info('CKAN core queries has been patched successfully.')

--- a/ckanext/knowledgehub/plugin.py
+++ b/ckanext/knowledgehub/plugin.py
@@ -8,7 +8,7 @@ from ckan.lib.plugins import DefaultDatasetForm
 import ckanext.knowledgehub.helpers as h
 
 from ckanext.knowledgehub.helpers import _register_blueprints
-
+from ckanext.knowledgehub.lib.search import patch_ckan_core_search
 
 class KnowledgehubPlugin(plugins.SingletonPlugin, DefaultDatasetForm):
     plugins.implements(plugins.IConfigurer)
@@ -25,6 +25,8 @@ class KnowledgehubPlugin(plugins.SingletonPlugin, DefaultDatasetForm):
         toolkit.add_template_directory(config_, 'templates')
         toolkit.add_public_directory(config_, 'public')
         toolkit.add_resource('fanstatic', 'knowledgehub')
+        # patch the CKAN core functionality
+        patch_ckan_core_search()
 
     # IBlueprint
     def get_blueprint(self):


### PR DESCRIPTION
Fix for error 500 when a dataset has the same name as dashboard, research question or visualization (or any other Solr indexed document).
Adds the 'entity_type:package' filter (fq) to Solr query, however this required patching of the CKAN core search functionalities.