### PR TITLE
Feature/search algorithm user interests boost

### DIFF
--- a/ckanext/knowledgehub/controllers/package.py
+++ b/ckanext/knowledgehub/controllers/package.py
@@ -16,6 +16,7 @@ from ckan.common import config
 import ckan.plugins as p
 import ckan.lib.base as base
 from ckan.lib.render import TemplateNotFound
+from ckan.lib.search import SearchError, SearchQueryError
 
 from ckanext.knowledgehub import helpers as kwh_h
 from ckanext.knowledgehub.lib.email import request_validation
@@ -65,8 +66,6 @@ class KWHPackageController(PackageController):
     """
 
     def search(self):
-        from ckan.lib.search import SearchError, SearchQueryError
-
         package_type = self._guess_package_type()
 
         try:
@@ -90,8 +89,8 @@ class KWHPackageController(PackageController):
                 }
 
                 kwh_data = {
-                    'type': 'search',
-                    'content': q
+                    'type': 'search_query',
+                    'title': q
                 }
                 logic.get_action(u'kwh_data_create')(
                     sysadmin_context, kwh_data

--- a/ckanext/knowledgehub/fanstatic/javascript/user_query_result.js
+++ b/ckanext/knowledgehub/fanstatic/javascript/user_query_result.js
@@ -23,42 +23,10 @@
     };
 
     function saveUserQueryResult(query_text, result_type, result_id, user_id) {
-        api.get('user_query_show', {
+        api.post('user_query_result_save', {
             query_text: query_text,
             query_type: result_type,
-            user_id: user_id
-        })
-        .done(function (data) {
-            if (data.success) {
-                var query_id = data.result.id
-                api.post('user_query_result_create', {
-                    query_id: query_id,
-                    result_type: result_type,
-                    result_id: result_id
-                })
-                .done(function (data) {
-                    console.log("User Query Result: SAVED!");
-                })
-                .fail(function (error) {
-                    console.log("User Query Result failed: " + error.statusText);
-                });
-            }
-        })
-        .fail(function (error) {
-            console.log("User Query Show failed: " + error.statusText);
-        });
-    }
-
-    function saveKnowledgeHubData(query_text) {
-        api.post('kwh_data_create', {
-            type: 'search_query',
-            title: query_text
-        })
-        .done(function (data) {
-            console.log("User query added to kwh data");
-        })
-        .fail(function (error) {
-            console.log("Failed to add user query to kwh data: " + error.statusText);
+            result_id: result_id,
         });
     }
 
@@ -66,22 +34,41 @@
         var save_user_query = function(callback) {
             var tab_content = $('.tab_content');
 
-            tab_content.on('click', '.dataset-heading', function() {
+            tab_content.on('click', '.dataset-heading', function(e) {
+                e.preventDefault();
+                e.stopPropagation();
                 var dataset_content = $(this).parent('.dataset-content');
                 var result_id = dataset_content.find('#dataset-id').val();
                 callback(DATASET_TYPE, result_id);
+                setTimeout(function(){
+                    window.location = $('a', this).attr('href');
+                }.bind(this), 0);
+                return false;
             });
 
-            tab_content.on('click', '.rq-heading', function () {
+            tab_content.on('click', '.rq-heading', function (e) {
+                e.preventDefault()
+                e.stopPropagation()
                 var rq_content = $(this).parent('.rq-box');
                 var result_id = rq_content.find('#rq-id').val();
                 callback(RQ_TYPE, result_id);
+                setTimeout(function(){  
+                    window.location = $('a', this).attr('href');
+                }.bind(this), 10);
+                return false;
             });
 
-            tab_content.on('click', '.dashboard-link', function () {
-                var dashboard_content = $(this).parent('#tabs-dashboards');
-                var result_id = dashboard_content.find('#dashboard-id').val();
+            tab_content.on('click', '.dashboard-link', function (e) {
+                e.preventDefault()
+                e.stopPropagation()
+                // var dashboard_content = $(this).parent('#tabs-dashboards');
+                // var result_id = dashboard_content.find('#dashboard-id').val();
+                var result_id = $(this).attr('id');
                 callback(DASHBOARD_TYPE, result_id);
+                setTimeout(function(){
+                    window.location = $(this).attr('href');
+                }.bind(this), 0);
+                return false;
             });
         }
 
@@ -94,7 +81,6 @@
                 if (query_text) {
                     var user_id = $('#user-id').val();
                     saveUserQueryResult(query_text, result_type, result_id, user_id)
-                    saveKnowledgeHubData(query_text, user_id)
                 }
             }
         });

--- a/ckanext/knowledgehub/lib/profile.py
+++ b/ckanext/knowledgehub/lib/profile.py
@@ -1,0 +1,211 @@
+'''User interests service.
+'''
+import json
+from ckan.lib.redis import connect_to_redis
+import ckan.model as model
+from ckan.common import config
+from ckan.plugins import toolkit as toolkit
+from ckan.lib.dictization import table_dictize
+
+from ckanext.knowledgehub.model.user_profile import UserProfile
+from ckanext.knowledgehub.model.query import UserQueryResult
+from logging import getLogger
+
+
+log = getLogger(__name__)
+
+
+class UserProfileService:
+    '''Service that manages user profile data such as interests and most recent
+    relevant searches.
+
+    It uses caching (in Redis) to store temporary user interests.
+
+    :param redis: The redis connection. If ommited, the default CKAN Redis
+        connection will be used
+    :param user_profile: `UserProfile`, model to be used for accessing the
+        user profile data
+    :param user_ques_result: `UserQueryResult`, model to be used for accessing
+        the relevant user queries.
+    '''
+
+    PROFILE_CACHE_PREFIX = 'ckanext.knowledgehub.user.profile'
+    # Cache timeout - default to 5 minutes
+    CACHE_TIMEOUT = config.get('ckanext.knowledgehub.cache_timeout', 5*60)
+    RELEVANT_SEARCHES = config.get('ckanext.knowledgehub.relevant_searches', 5)
+
+    def __init__(self, redis=None, user_profile=UserProfile,
+                 user_query_result=UserQueryResult):
+        self.redis = redis or connect_to_redis()
+        self.user_profile = user_profile
+        self.user_query_result = user_query_result
+
+    def _get_key(self, user_id, suffix=None):
+        if suffix:
+            return '%s.%s:%s' % (UserProfileService.PROFILE_CACHE_PREFIX,
+                                 suffix, user_id)
+        return '%s:%s' % (UserProfileService.PROFILE_CACHE_PREFIX, user_id)
+
+    def get_profile(self, user_id):
+        '''Returns the user profile as a dict.
+
+        :param user_id: `str`, the user id.
+
+        :returns: `dict`, the user profile data.
+        '''
+        profile = self.user_profile.by_user_id(user_id)
+        if not profile:
+            return None
+        context = {
+            'model': model,
+            'session': model.Session,
+        }
+        profile = table_dictize(profile, context)
+
+        return profile
+
+    def get_interests(self, user_id):
+        '''Returns the user interests as a dict.
+
+        :param user_id: `str`, the user id.
+
+        :returns: `dict`, the user interests as set in the user profile.
+        '''
+        profile = self.get_profile(user_id) or {}
+        return profile.get('interests')
+
+    def get_interests_boost(self, user_id):
+        '''Returns the interests to be used as boost parameters in the queries
+        to the Solr indexer.
+
+        The response dict contains the names and the values of the fields that
+        should be boosted alog with the coefficient of boosting. For example:
+
+            .. code-block: json
+
+                {
+                    "normal": {
+                        "idx_keywords": ["k1", "k2"]  // boost idx_keywords
+                                                      // with standard boost
+                    },
+                    "^0.5": {
+                        "idx_keywords": ["k3", "k4"]  // boost with coeff 0.5
+                                                      // when idx_keywords has
+                                                      // value k3 or k4
+                    }
+                }
+        '''
+        cached = self.redis.get(self._get_key(user_id, 'boost_params'))
+        if cached:
+            return json.loads(cached)
+
+        interests = self.get_interests(user_id) or {}
+
+        relevant = self.get_last_relevant(user_id)
+
+        searches = {}
+        for k, values in relevant.items():
+            searches[k] = []
+            for v in values:
+                if v not in interests.get(k, []):
+                    searches[k].append(v)
+
+        values = {
+            'normal': {
+                'idx_keywords': sorted(interests.get('keywords', [])),
+                'idx_tags': sorted(interests.get('tags', [])),
+                'idx_research_questions': sorted(
+                    interests.get('research_questions', [])),
+            },
+            '^0.5': {
+                'idx_keywords': sorted(searches.get('keywords', [])),
+                'idx_tags': sorted(searches.get('tags', [])),
+                'idx_research_questions': sorted(
+                    searches.get('research_questions', [])),
+            }
+        }
+
+        self.redis.setex(self._get_key(user_id, 'boost_params'),
+                         json.dumps(values),
+                         UserProfileService.CACHE_TIMEOUT)
+
+        return values
+
+    def get_last_relevant(self, user_id):
+        '''Returns the last relevant tags, keywords and research questions from
+        the user queries in the system.
+        '''
+        relevant = {
+            'tags': set(),
+            'keywords': set(),
+            'research_questions': set(),
+        }
+
+        def _action(action_name, context, data_dict):
+            try:
+                return toolkit.get_action(action_name)(context, data_dict)
+            except Exception as e:
+                log.warning('Failed to execute %s. Error: %s',
+                            action_name, str(e))
+            return None
+
+        keywords = set()
+
+        for package_id in self.user_query_result.get_last_relevant(
+                user_id,
+                'dataset',
+                UserProfileService.RELEVANT_SEARCHES):
+            package = _action('package_show', {
+                'ignore_auth': True,
+            }, {
+                'id': package_id
+            })
+            if package:
+                for tag in package.get('tags', []):
+                    relevant['tags'].add(tag['name'])
+                    if tag.get('keyword_id'):
+                        keywords.add(tag['keyword_id'])
+
+                for keyword in package.get('keywords', []):
+                    keywords.add(keyword)
+
+        for rq in self.user_query_result.get_last_relevant(
+                user_id,
+                'research_question',
+                UserProfileService.RELEVANT_SEARCHES):
+            relevant['research_questions'].add(rq)
+
+        for dashboard in self.user_query_result.get_last_relevant(
+                user_id,
+                'dashboard',
+                UserProfileService.RELEVANT_SEARCHES):
+            dashboard = _action('dashboard_show', {
+                'ignore_auth': True
+            }, {
+                'id': dashboard
+            })
+            if dashboard and dashboard.get('tags'):
+                for tag in dashboard['tags'].split(','):
+                    tag = _action('tag_show', {
+                        'ignore_auth': True
+                    }, {
+                        'id': tag
+                    })
+                    if tag:
+                        relevant['tags'].add(tag['name'])
+                        if tag.get('keyword_id') is not None:
+                            keywords.add(tag['keyword_id'])
+
+        for keyword in keywords:
+            keyword = _action('keyword_show', {
+                'ignore_auth': True
+            }, {
+                'id': keyword
+            })
+            if keyword:
+                relevant['keywords'].add(keyword['name'])
+
+        return relevant
+
+
+user_profile_service = UserProfileService()

--- a/ckanext/knowledgehub/lib/solr.py
+++ b/ckanext/knowledgehub/lib/solr.py
@@ -558,6 +558,10 @@ class Indexed:
 def boost_solr_params(values):
     '''Transforms the values dict into edismax solr query arguments.
     '''
+
+    if not values:
+        return {}
+
     params = {
         'defType': 'edismax',
     }

--- a/ckanext/knowledgehub/lib/solr.py
+++ b/ckanext/knowledgehub/lib/solr.py
@@ -13,7 +13,8 @@ FIELD_PREFIX = 'khe_'
 COMMON_FIELDS = {'name', 'title'}
 CHUNK_SIZE = 1000
 MAX_RESULTS = 500
-VALID_SOLR_ARGS = {'q', 'fq', 'rows', 'start', 'sort', 'fl', 'df', 'facet'}
+VALID_SOLR_ARGS = {'q', 'fq', 'rows', 'start', 'sort', 'fl', 'df', 'facet',
+                   'bq', 'defType', 'boost'}
 DEFAULT_FACET_NAMES = u'organizations groups tags'
 
 
@@ -515,6 +516,15 @@ class Indexed:
         The query arguments are going to be translated into valid Solr query
         parameters.
         '''
+
+        if query.get('boost_for'):
+            # Delay the loading of the user_profile service
+            from ckanext.knowledgehub.lib.profile import user_profile_service
+            user_id = query.pop('boost_for')
+            boost_values = user_profile_service.get_interests_boost(user_id)
+            boost_params = boost_solr_params(boost_values)
+            query.update(boost_params)
+
         Indexed.validate_solr_args(query)
         index_results = cls.get_index().search(cls._get_doctype(), **query)
         results = []
@@ -543,3 +553,27 @@ class Indexed:
         args = {}
         args[id_key] = doc_id
         cls.get_index().remove(doctype, **args)
+
+
+def boost_solr_params(values):
+    '''Transforms the values dict into edismax solr query arguments.
+    '''
+    params = {
+        'defType': 'edismax',
+    }
+
+    bq = []
+    for prop, prop_values in values.get('normal', {}).items():
+        for value in prop_values:
+            bq.append("%s:'%s'" % (prop, value))
+
+    for scale, boost_params in values.items():
+        if scale == 'normal':
+            continue
+        for prop, prop_values in boost_params.items():
+            for value in prop_values:
+                bq.append("%s:'%s'%s" % (prop, value, scale))
+
+    if bq:
+        params['bq'] = ' OR '.join(bq)
+    return params

--- a/ckanext/knowledgehub/logic/action/create.py
+++ b/ckanext/knowledgehub/logic/action/create.py
@@ -1167,12 +1167,70 @@ def user_profile_create(context, data_dict):
                           user_notified=False,
                           interests={})
 
-    for interest_type in ['research_questions', 'tags', 'keywords']:
+    for interest_type in ['research_questions', 'keywords']:
         if data_dict.get(interest_type):
             profile.interests[interest_type] = data_dict[interest_type]
+
+    
+    profile.interests['tags'] = []
+    for tag in data_dict.get('tags', []):
+        try:
+            tag = toolkit.get_action('tag_show')({
+                'ignore_auth': True,
+            },{
+                'id': tag,
+            })
+            profile.interests['tags'].append(tag['name'])
+        except Exception as e:
+            log.warning('Failed to load tag %s. Error: %s', tag, str(e))
 
     profile.save()
     model.Session.flush()
 
     profile_dict = _table_dictize(profile, context)
     return profile_dict
+
+
+def user_query_result_save(context, data_dict):
+    '''Saves the result of a query when a user clicks on a link.
+
+    :param query_text: `str` the text of the query
+    :param query_type: `str` the type of search query: dataset, dashboard etc.
+    :param result_id: `str` the id of the selected object like dataset id,
+        dashboard id etc.
+    '''
+    query_text = data_dict.get('query_text')
+    query_type = data_dict.get('query_type')
+    result_id = data_dict.get('result_id')
+    user = context.get('auth_user_obj')
+    if not (query_text and query_type and result_id and user):
+        return {}  # just pass through, we don't have to generate error
+
+    try:
+        user_query = toolkit.get_action('user_query_show')({
+            'ignore_auth': True,
+        }, {
+            'query_text': query_text,
+            'query_type': query_type,
+            'user_id': user.id,
+        })
+
+        user_query_result_create(context, {
+            'query_id': user_query['id'],
+            'result_type': query_type,
+            'result_id': result_id,
+        })
+    except Exception as e:
+        log.warning('Cannot fetch user_query. Error: %s', str(e))
+        log.exception(e)
+    
+    try:
+        kwh_data_create(context, {
+            'type': 'search_query',
+            'title': query_text,
+        })
+    except Exception as e:
+        log.warning('Failed to store kwh_data. Error: %s', str(e))
+        log.exception(e)
+    
+    return {}

--- a/ckanext/knowledgehub/logic/action/get.py
+++ b/ckanext/knowledgehub/logic/action/get.py
@@ -7,6 +7,7 @@ from six import string_types, iteritems
 from paste.deploy.converters import asbool
 
 import ckan.logic as logic
+from ckan.logic.action.get import package_search as ckan_package_search
 from ckan.plugins import toolkit
 from ckan.common import _, config, json
 from ckan import lib
@@ -903,6 +904,10 @@ def _search_entity(index, ctx, data_dict):
     _save_user_query(ctx, text, index.doctype)
 
     args = ckan_params_to_solr_args(data_dict)
+
+    if ctx.get('auth_user_obj'):
+        args['boost_for'] = ctx['auth_user_obj'].id
+
     results = index.search_index(**args)
 
     results.page = page
@@ -1832,3 +1837,14 @@ def tag_show(context, data_dict):
     check_access('tag_show', context, data_dict)
     return model_dictize.tag_dictize(tag, context,
                                      include_datasets=include_datasets)
+
+
+def package_search(context, data_dict=None):
+    '''Overrides CKAN's package_search action to add boost parameters for the
+    user interests.
+    '''
+    user = context.get('auth_user_obj')
+    if user:
+        data_dict = data_dict or {}
+        data_dict['boost_for'] = user.id
+    return ckan_package_search(context, data_dict)

--- a/ckanext/knowledgehub/logic/action/update.py
+++ b/ckanext/knowledgehub/logic/action/update.py
@@ -1431,10 +1431,25 @@ def user_profile_update(context, data_dict):
         profile.interests = {}
 
     interests = data_dict.get('interests', {})
-    for interest_type in ['research_questions', 'keywords', 'tags']:
+    for interest_type in ['research_questions', 'keywords']:
         if interests.get(interest_type) is not None:
             profile.interests[interest_type] = interests[interest_type]
 
+    
+    if interests.get('tags') is not None:
+        profile.interests['tags'] = []
+        for tag in interests.get('tags', []):
+            try:
+                tag = toolkit.get_action('tag_show')({
+                    'ignore_auth': True,
+                }, {
+                    'id': tag,
+                })
+                profile.interests['tags'].append(tag['name'])
+            except Exception as e:
+                log.warning('Failed to load tag %s. Error: %s', tag, str(e))
+
+    
     if profile.interests:
         flag_modified(profile, 'interests')
 

--- a/ckanext/knowledgehub/logic/auth/get.py
+++ b/ckanext/knowledgehub/logic/auth/get.py
@@ -1,6 +1,9 @@
 import ckan.plugins.toolkit as toolkit
 import ckan.lib.helpers as h
-from ckan.logic.auth.get import tag_list as ckan_tag_list
+from ckan.logic.auth.get import (
+    tag_list as ckan_tag_list,
+    package_search as ckan_package_search,
+)
 from ckan.logic import chained_action
 
 
@@ -142,3 +145,7 @@ def user_profile_show(context, data_dict):
 
 def user_profile_list(context, data_dict=None):
     return {'success': False}
+
+
+def package_search(context, data_dict=None):
+    return ckan_package_search(context, data_dict)

--- a/ckanext/knowledgehub/model/dashboard.py
+++ b/ckanext/knowledgehub/model/dashboard.py
@@ -90,7 +90,7 @@ class Dashboard(DomainObject, Indexed):
                 docs = get_action('search_visualizations')(
                     {'ignore_auth': True},
                     {'text': '*', 'fq': 'entity_id:' + k['resource_view_id']}
-                )
+                ) if k.get('resource_view_id') else {}
                 for v in docs.get('results', []):
                     organization = v.get('organizations')
                     if organization:

--- a/ckanext/knowledgehub/model/query.py
+++ b/ckanext/knowledgehub/model/query.py
@@ -4,6 +4,7 @@ from ckan.model.types import make_uuid
 from ckan.model.domain_object import DomainObject
 
 from sqlalchemy import types, ForeignKey, Column, Table, or_
+from sqlalchemy.sql.expression import func
 import datetime
 import logging
 
@@ -145,6 +146,20 @@ class UserQueryResult(DomainObject):
             query = query.offset(offset)
 
         return query.all()
+    
+    @classmethod
+    def get_last_relevant(cls, user_id, result_type, limit=5):
+        query = Session.query(
+            user_query_result.c.result_id
+        )
+        query = query.filter(
+            user_query_result.c.user_id == user_id,
+            user_query_result.c.result_type == result_type)
+        query = query.group_by(user_query_result.c.result_id)
+        query = query.order_by(user_query_result.c.result_id.desc())
+        results = query.limit(limit).all()
+
+        return [r[0] for r in results]
 
 
 mapper(UserQuery, user_query)

--- a/ckanext/knowledgehub/plugin.py
+++ b/ckanext/knowledgehub/plugin.py
@@ -240,6 +240,7 @@ class KnowledgehubPlugin(plugins.SingletonPlugin, DefaultDatasetForm):
             'dq_timeliness_column': defaults,
             'dq_timeliness_date_format': defaults,
             'dq_accuracy_column': defaults,
+            'data_quality_completeness_column': defaults,
         })
         return schema
 

--- a/ckanext/knowledgehub/plugin.py
+++ b/ckanext/knowledgehub/plugin.py
@@ -93,6 +93,10 @@ class KnowledgehubPlugin(plugins.SingletonPlugin, DefaultDatasetForm):
         module_root = 'ckanext.knowledgehub.logic.auth'
         auth_functions = h._get_functions(module_root)
 
+        # When setting the auth function, CKAN will try to authorize every call
+        # to the action, which is not desireable for package search.
+        auth_functions.pop('package_search')
+
         return auth_functions
 
     # ITemplateHelpers

--- a/ckanext/knowledgehub/templates/package/search.html
+++ b/ckanext/knowledgehub/templates/package/search.html
@@ -283,7 +283,9 @@
                                     <div id="tabs-dashboards" class="dataset-content">
                                         {% set additional_info_dash = h.get_single_dash(dashboard) %}
                                             <h3 class="dataset-heading text-ellipsis">
-                                                <a href="{{ h.url_for('dashboards.view', name=dashboard.name) }}">{{ dashboard.title }}</a>
+                                                <a href="{{ h.url_for('dashboards.view', name=dashboard.name) }}" 
+                                                   class="dashboard-link"
+                                                   id="{{ dashboard.id }}">{{ dashboard.title }}</a>
                                             </h3>
                                                 {% set truncate = truncate or 180 %}
                                                 {% set truncate_description = truncate_description or 150 %}

--- a/ckanext/knowledgehub/tests/test_actions.py
+++ b/ckanext/knowledgehub/tests/test_actions.py
@@ -2452,7 +2452,23 @@ class TestUserProfileActions(ActionsBase):
         assert_true(user_profile is not None)
         assert_equals(user_profile.get('user_id'), context['auth_user_obj'].id)
 
+    @monkey_patch(toolkit, 'get_action', mock.MagicMock())
     def test_user_profile_update(self):
+
+        def _get_action(action):
+            if action != 'tag_show':
+                raise Exception('Unmocked action: ' + action)
+
+            def _tag_show(ctx, data):
+                return {
+                    'id': data['id'],
+                    'name': data['id'],
+                }
+            
+            return _tag_show
+
+        toolkit.get_action.side_effect =  _get_action   
+
         context = get_regular_user_context()
 
         user_profile = update_actions.user_profile_update(context, {})

--- a/ckanext/knowledgehub/tests/test_helpers.py
+++ b/ckanext/knowledgehub/tests/test_helpers.py
@@ -10,6 +10,7 @@ from ckan import plugins
 from ckan.tests import helpers
 from ckan.plugins import toolkit as toolkit
 from ckan import model
+from ckan.common import g
 
 from ckanext.knowledgehub.model.theme import theme_db_setup
 from ckanext.knowledgehub.model.research_question import (
@@ -40,6 +41,7 @@ from ckanext.knowledgehub.tests.helpers import (User,
 from ckanext.datastore.logic.action import datastore_create
 from ckanext.datastore.logic.action import datastore_search
 from ckanext.knowledgehub.lib.util import monkey_patch
+from ckanext.knowledgehub.tests.helpers import get_context
 
 assert_equals = nose.tools.assert_equals
 assert_raises = nose.tools.assert_raises
@@ -216,7 +218,15 @@ class TestKWHHelpers(ActionsBase):
         }
         dashboard = create_actions.dashboard_create(context, data_dict)
 
-        dashboards = kwh_helpers.get_rqs_dashboards('Test')
+        ctx = get_context()
+
+        g.user = ctx.get('user')
+        g.userobj = ctx.get('auth_user_obj')
+        try:
+            dashboards = kwh_helpers.get_rqs_dashboards('Test')
+        finally:
+            del g.user
+            del g.userobj
 
         assert_equals(len(dashboards), 0)
 

--- a/ckanext/knowledgehub/tests/test_lib_profile.py
+++ b/ckanext/knowledgehub/tests/test_lib_profile.py
@@ -1,0 +1,172 @@
+from mock import Mock, patch, MagicMock
+
+from ckanext.knowledgehub.lib.profile import UserProfileService
+from ckanext.knowledgehub.model.user_profile import UserProfile
+from ckanext.knowledgehub.lib.util import monkey_patch
+from ckan.plugins import toolkit as toolkit
+
+from nose.tools import (
+    assert_true,
+    assert_equals,
+    raises,
+)
+
+
+class TestUserProfileService:
+
+    def test_get_profile(self):
+        user_profile_mock = MagicMock()
+        service = UserProfileService(redis=MagicMock(),
+                                     user_profile=user_profile_mock,
+                                     user_query_result=MagicMock())
+
+        user_profile_mock.by_user_id.return_value = UserProfile()
+
+        profile = service.get_profile('user-001')
+        assert_true(profile is not None)
+
+    def test_get_interests(self):
+        service = UserProfileService(redis=MagicMock(),
+                                     user_profile=MagicMock(),
+                                     user_query_result=MagicMock())
+        service.get_profile = Mock()
+        interests = {
+            'tags': ['tag1', 'tag2'],
+            'keywords': ['keyword1', 'keyword2'],
+            'research_questions': ['rq1', 'rq2'],
+        }
+        service.get_profile.return_value = {
+            'interests': interests,
+        }
+
+        result = service.get_interests('user-001')
+        assert_true(result is not None)
+        assert_equals(result, interests)
+        service.get_profile.assert_called_once_with('user-001')
+
+    @monkey_patch(toolkit, 'get_action', MagicMock())
+    def test_get_last_relevant(self):
+        datasets = {
+            'pkg1': {
+                'tags': [{'id': 't1', 'name': 't1', 'keyword_id': 'k1'}],
+                'keywords': ['k1']
+            },
+            'pkg2': {
+                'tags': [{'id': 't2', 'name': 't2'}]
+            },
+            'pkg3': {},
+            'pkg4': {
+                'tags': [{'id': 't3', 'name': 't3', 'keyword_id': 'k3'}],
+                'keywords': ['k3']
+            },
+            'pkg5': {
+                'tags': [{'id': 't1', 'name': 't1', 'keyword_id': 'k1'}],
+                'keywords': ['k1']
+            },
+        }
+
+        tags = {
+            't1': {'id': 't1', 'name': 't1', 'keyword_id': 'k1'},
+            't2': {'id': 't2', 'name': 't2'},
+            't3': {'id': 't3', 'name': 't3', 'keyword_id': 'k3'},
+            't4': {'id': 't4', 'name': 't4', 'keyword_id': 'k4'},
+            't5': {'id': 't5', 'name': 't5', 'keyword_id': 'k4'},
+        }
+
+        keywords = {
+            'k1': {'id': 'k1', 'name': 'k1'},
+            'k2': {'id': 'k2', 'name': 'k2'},
+            'k3': {'id': 'k3', 'name': 'k3'},
+            'k4': {'id': 'k4', 'name': 'k4'},
+        }
+
+        dashboards = {
+            'd1': {'id': 'd1', 'tags': 't1,t3'},
+            'd2': {'id': 'd2', 'tags': 't2,t3'},
+            'd3': {'id': 'd3', 'tags': 't4,t5'},
+        }
+
+        def _get(col, key):
+            if key not in col:
+                raise Exception('Not found: ' + str(key))
+            return col[key]
+
+        _actions = {
+            'package_show': lambda ctx, dd: _get(datasets, dd['id']),
+            'tag_show': lambda ctx, dd: _get(tags, dd['id']),
+            'keyword_show': lambda ctx, dd: _get(keywords, dd['id']),
+            'dashboard_show': lambda ctx, dd: _get(dashboards, dd['id']),
+        }
+
+        def _get_action(action):
+            return _actions[action]
+
+        toolkit.get_action.side_effect = _get_action
+
+        user_query_result_mock = MagicMock()
+
+        def _get_last_relevant_mock(user_id, _type, _max):
+            if _type == 'dataset':
+                return ['pkg1', 'pkg2', 'pkg3', 'pkg4', 'pkg5']
+            elif _type == 'research_question':
+                return ['rq1', 'rq2', 'rq3']
+            elif _type == 'dashboard':
+                return ['d1', 'd2', 'd3']
+            raise Exception('Invalid type: ' + _type)
+
+        user_query_result_mock.get_last_relevant.side_effect = \
+            _get_last_relevant_mock
+
+        service = UserProfileService(redis=MagicMock(),
+                                     user_profile=MagicMock(),
+                                     user_query_result=user_query_result_mock)
+
+        relevant = service.get_last_relevant('user-001')
+        assert_true(relevant is not None)
+        assert_equals(relevant, {
+            'research_questions': set(['rq1', 'rq2', 'rq3']),
+            'keywords': set(['k1', 'k3', 'k4']),
+            'tags': set(['t1', 't2', 't3', 't4', 't5'])
+        })
+
+    def test_interests_boost(self):
+        redis_mock = MagicMock()
+
+        redis_mock.get.return_value = None
+
+        service = UserProfileService(redis_mock, MagicMock(), MagicMock())
+
+        interests = {
+            'keywords': ['k1', 'k2'],
+            'tags': ['t1', 't2'],
+            'research_questions': ['rq1', 'rq2'],
+        }
+
+        searches = {
+            'keywords': set(['k3', 'k4']),
+            'tags': set(['t3', 't4']),
+            'research_questions': set(['rq3', 'rq4']),
+        }
+
+        service.get_interests = Mock()
+        service.get_last_relevant = Mock()
+
+        service.get_interests.return_value = interests
+        service.get_last_relevant.return_value = searches
+
+        result = service.get_interests_boost('user-001')
+
+        assert_true(result is not None)
+        assert_equals(result, {
+            'normal': {
+                'idx_keywords': ['k1', 'k2'],
+                'idx_tags': ['t1', 't2'],
+                'idx_research_questions': ['rq1', 'rq2'],
+            },
+            '^0.5': {
+                'idx_keywords': ['k3', 'k4'],
+                'idx_tags': ['t3', 't4'],
+                'idx_research_questions': ['rq3', 'rq4'],
+            }
+        })
+        assert_equals(redis_mock.setex.call_count, 1)

--- a/ckanext/knowledgehub/tests/test_lib_profile.py
+++ b/ckanext/knowledgehub/tests/test_lib_profile.py
@@ -134,7 +134,9 @@ class TestUserProfileService:
 
         redis_mock.get.return_value = None
 
-        service = UserProfileService(redis_mock, MagicMock(), MagicMock())
+        service = UserProfileService(MagicMock(), MagicMock(), MagicMock())
+        service._connect = Mock()
+        service._connect.return_value = redis_mock
 
         interests = {
             'keywords': ['k1', 'k2'],


### PR DESCRIPTION
Adds edismax boost query to the regular CKAN search to reorder the search parameters when doing search for dataset, research question, dashboard and visualization, based on the user interests and previous user searches.

Also fixes the problems with error 403 and fixes the usage of the Redis connection (fixes error 500).