### PR TITLE
Fix - visualiations charts

### DIFF
--- a/ckanext/knowledgehub/fanstatic/javascript/modules/chart.js
+++ b/ckanext/knowledgehub/fanstatic/javascript/modules/chart.js
@@ -430,7 +430,13 @@ ckan.module('chart', function () {
                         },
                         x: {
                             type: 'category',
-                            categories: categories.map(val => val.length > 13 ? val.substring(0, 11) + "..." : val),
+                            //categories: categories.map(val => val.length > 13 ? val.substring(0, 11) + "..." : val),
+                            categories: categories.map(function(val){
+                                if (val && val.length > 13){
+                                    return val.substring(0, 11) + "...";
+                                }
+                                return val;
+                            }),
                             tick: {
                                 count: tick_count,
                                 rotate: x_text_rotate,
@@ -463,7 +469,13 @@ ckan.module('chart', function () {
                         },
                         x: {
                             type: 'category',
-                            categories: categories.map(val => val.length > 13 ? val.substring(0, 11) + "..." : val),
+                            // categories: categories.map(val => val.length > 13 ? val.substring(0, 11) + "..." : val),
+                            categories: categories.map(function(val){
+                                if (val && val.length > 13){
+                                    return val.substring(0, 11) + "...";
+                                }
+                                return val;
+                            }),
                             tick: {
                                 rotate: x_text_rotate,
                                 multiline: x_text_multiline,
@@ -536,7 +548,7 @@ ckan.module('chart', function () {
 
                 info.map(val => {
                     var x = $(".c3-title", chart.element).attr('x');
-                    //var element = document.createElementNS('http://www.w3.org/2000/svg', 'tspan');
+                    var element = document.createElementNS('http://www.w3.org/2000/svg', 'tspan');
                     val.length > 30 ? val = val.substring(0, 30) + "..." : null;
                     element.textContent = val;
                     element.setAttributeNS(null, 'dy', '1.2em');
@@ -886,8 +898,8 @@ ckan.module('chart', function () {
 $(document).ready(function () {
 
     // hide these at the beginning
-    document.getElementById('chart_field_additional_tornado_value').style.display = "none"
-    document.getElementById('chart_additional_tornado_label').style.display = "none"
+    $('#chart_field_additional_tornado_value').css('display', 'none'); 
+    $('#chart_additional_tornado_label').css('display', 'none'); 
 
     $('#chart_field_type').change(function () {
         var e = document.getElementById("chart_field_type");

--- a/ckanext/knowledgehub/helpers.py
+++ b/ckanext/knowledgehub/helpers.py
@@ -36,6 +36,7 @@ from ckanext.knowledgehub.model import ResourceValidation
 log = logging.getLogger(__name__)
 model_dictize = lib.dictization.model_dictize
 
+
 SYSTEM_RESOURCE_TYPE = 'system_merge'
 INVALID_COLUMN_NAMES = ['_id', '_full_text']
 
@@ -946,10 +947,13 @@ def get_searched_visuals(query):
     visuals = []
     for vis in list_visuals_searched['results']:
         visual = model.Session.query(ResourceView)\
-            .filter(ResourceView.id == vis['id'])
-        data_dict_format = model_dictize\
-            .resource_view_list_dictize(visual, _get_context())
-        visuals.append(data_dict_format)
+            .get(vis['id'])
+        try:
+            data_dict_format = model_dictize\
+                .resource_view_list_dictize([visual], _get_context())
+            visuals.append(data_dict_format[0])
+        except  Exception as e:
+            log.exception(e)
 
     list_visuals_searched['results'] = visuals
     list_visuals_searched['pager'] = _get_pager(list_visuals_searched,

--- a/ckanext/knowledgehub/logic/action/get.py
+++ b/ckanext/knowledgehub/logic/action/get.py
@@ -1028,6 +1028,12 @@ def search_visualizations(context, data_dict):
 
     :returns: ``list``, the documents matching the search query from the index.
     '''
+    fq = data_dict.get('fq', [])
+    if isinstance(fq, str) or isinstance(fq, unicode):
+        fq = [fq]
+    fq.append('khe_view_type:chart')
+    data_dict['fq'] = fq
+
     return _search_entity(Visualization, context, data_dict)
 
 

--- a/ckanext/knowledgehub/model/visualization.py
+++ b/ckanext/knowledgehub/model/visualization.py
@@ -4,7 +4,12 @@ from ckan.logic import get_action
 
 from sqlalchemy import Column, types
 
-from ckanext.knowledgehub.lib.solr import Indexed, mapped, unprefixed
+from ckanext.knowledgehub.lib.solr import (
+    Indexed,
+    mapped,
+    unprefixed,
+    DontIndexException
+)
 import json
 
 class Visualization(ResourceView, Indexed):
@@ -30,6 +35,10 @@ class Visualization(ResourceView, Indexed):
 
     @staticmethod
     def before_index(data):
+        # Index only charts
+        if data.get('view_type') not in  ['chart', 'map']:
+            raise DontIndexException(data.get('id'))
+
         resource_view = get_action('resource_view_show')(
             {'ignore_auth': True},
             {'id': data['id']})

--- a/ckanext/knowledgehub/templates/package/search.html
+++ b/ckanext/knowledgehub/templates/package/search.html
@@ -193,7 +193,6 @@
                             <div class="flex flex-wrap" id="tabs-visualizations">
                                 {% set vis = search_results.results %}
                                 {% for resource_view in vis %}
-                                {% set resource_view = resource_view[0] %}
                                 <div class="col-xs-12 visualizations">
                                     {% if resource_view.view_type == 'chart' %}
                                     {% set chart_id = resource_view.id %}


### PR DESCRIPTION
Fixes the loading of visualizations.
Limits the indexing of visualizations only to `chart` and `map` because other types (like `recline_view`) should not appear in the search.

Although not strictly needed, I recommend rebuilding the search index for visualizations to update the entries in Solr as well:
```
knowlegdehub -c /etc/ckan/default/development.ini search-index rebuild --model=visualizaiton
```