### PR TITLE
Feature: Share Datasets and Dashboards with specific users, organizations or groups

### DIFF
--- a/ckanext/knowledgehub/cli/index.py
+++ b/ckanext/knowledgehub/cli/index.py
@@ -12,17 +12,19 @@ from ckanext.knowledgehub.model import (
 logger = getLogger(__name__)
 
 
+def _mock_translator():
+    # Workaround until the core translation function defaults to the Flask one
+    from paste.registry import Registry
+    from ckan.lib.cli import MockTranslator
+    registry = Registry()
+    registry.prepare()
+    from pylons import translator
+    registry.register(translator, MockTranslator())
+
+
 class CkanCoreIndex:
 
     def rebuild_index(self):
-        # Workaround until the core translation function defaults to the Flask one
-        from paste.registry import Registry
-        from ckan.lib.cli import MockTranslator
-        registry = Registry()
-        registry.prepare()
-        from pylons import translator
-        registry.register(translator, MockTranslator())
-        
         rebuild()
 
 
@@ -57,6 +59,7 @@ def rebuild_index_for(doctype):
               help='Rebuild index for specified model type. Available are: ' +
                    ','.join(sorted([k for k, _ in INDEX_EXECUTORS.items()])))
 def rebuild_index(model):
+    _mock_translator()
     types = [model]
     if model == 'all':
         # TODO: Add CKAN search index rebuild here.

--- a/ckanext/knowledgehub/fanstatic/javascript/modules/dashboard_viz_rq.js
+++ b/ckanext/knowledgehub/fanstatic/javascript/modules/dashboard_viz_rq.js
@@ -43,7 +43,7 @@ ckan.module('knowledgehub-dashboard-viz-rq', function ($) {
                 return;
             }
 
-            var RQValue = this.el.find('option[value=' + this.el.val() + ']').text()
+            var RQValue = $('option[value=' + this.el.val() + ']').val()
 
             if (RQValue) {
                 api.get('visualizations_for_rq', { research_question: RQValue})

--- a/ckanext/knowledgehub/helpers.py
+++ b/ckanext/knowledgehub/helpers.py
@@ -781,9 +781,12 @@ def remove_space_for_url(str):
     return str.replace(" ", "-")
 
 
-def format_date(str):
+def format_date(date_str):
     # split date & time
-    date = str.split('T')  # date[0] is the date, date[1] is the time
+    if isinstance(date_str, datetime):
+        date_str = date_str.isoformat()
+
+    date = date_str.split('T')  # date[0] is the date, date[1] is the time
     time_basic = date[1].split('.')  # time_basic[0] = hh/mm/ss
     # remove seconds
     time_basic[0] = time_basic[0][:-3]
@@ -838,7 +841,7 @@ def _get_facets():
     facets = []
     for param, value in request.params.items():
         if param in ['organization', 'groups', 'tags']:
-            facets.append('%s:%s' %(param, value))
+            facets.append('%s:%s' % (param, value))
 
     return facets
 
@@ -955,7 +958,7 @@ def get_searched_visuals(query):
             data_dict_format = model_dictize\
                 .resource_view_list_dictize([visual], _get_context())
             visuals.append(data_dict_format[0])
-        except  Exception as e:
+        except Exception as e:
             log.exception(e)
 
     list_visuals_searched['results'] = visuals
@@ -1560,7 +1563,8 @@ def shared_with_users_notification(editor_obj, users, data, entity, perm):
 
 
 def get_all_organizations():
-    return toolkit.get_action('get_all_organizations')({'ignore_auth': True}, {})
+    return toolkit.get_action('get_all_organizations')(
+        {'ignore_auth': True}, {})
 
 
 def get_all_groups():

--- a/ckanext/knowledgehub/helpers.py
+++ b/ckanext/knowledgehub/helpers.py
@@ -1555,3 +1555,11 @@ def shared_with_users_notification(editor_obj, users, data, entity, perm):
                 {'ignore_auth': True}, data_dict)
         except Exception as e:
             log.debug('Unable to send notification: %s' % str(e))
+
+
+def get_all_organizations():
+    return toolkit.get_action('get_all_organizations')({'ignore_auth': True}, {})
+
+
+def get_all_groups():
+    return toolkit.get_action('get_all_groups')({'ignore_auth': True}, {})

--- a/ckanext/knowledgehub/lib/solr.py
+++ b/ckanext/knowledgehub/lib/solr.py
@@ -610,67 +610,6 @@ def boost_solr_params(values):
     return params
 
 
-_PERMISSION_LABEL_PREFIX = {
-    'shared_with_users': 'user-%s',
-    'shared_with_organizations': 'member-%s',
-    'shared_with_groups': 'member-%s',
-}
-
-def get_permission_labels(data_dict):
-    permission_labels = data_dict.get('permission_labels', [])
-
-    for field, prefix_template in _PERMISSION_LABEL_PREFIX.items():
-        if data_dict.get(field):
-            ids = [s.strip() for s in data_dict[field].strip().split(',')]
-            for id in ids:
-                if id:
-                    label = prefix_template % id
-                    if label not in permission_labels:
-                        permission_labels.append(label)
-    
-    return permission_labels
-
-
-from ckan import model
-from ckan.model.meta import Session
-
-def get_user_permission_labels(context):
-    labels = ['public']
-
-    if context.get('auth_user_obj') is not None:
-        user = context['auth_user_obj']
-        labels.append('user-%s' % user.id)
-        labels.append('creator-%s' % user.id)
-
-        organizations, groups = _get_all_orgs_or_groups_for_user(user.id)
-
-        for ids in [organizations, groups]:
-            if ids:
-                if len(ids) > 1:
-                    labels.append('member-%s' % '-'.join(ids))
-                for _id in ids:
-                    labels.append('member-%s' % _id)
-
-    return labels
-
-
-def _get_all_orgs_or_groups_for_user(user_id):
-    q = Session.query(model.Member, model.Group)
-    q = q.join(model.Group,
-               model.member_table.c.group_id == model.group_table.c.id)
-    q = q.filter(model.member_table.c.table_id == user_id)
-    q = q.filter(model.member_table.c.table_name == 'user')
-
-    organizations, groups = [], []
-
-    for _,group in q.all():
-        if group.is_organization:
-            organizations.append(group.id)
-        else:
-            groups.append(group.id)
-    
-    return (organizations, groups)
-
 def get_fq_permission_labels(permission_labels):
     fq = '+permission_labels:'
     fq += '(' + ' OR '.join([escape_str(label) for label in \

--- a/ckanext/knowledgehub/lib/solr.py
+++ b/ckanext/knowledgehub/lib/solr.py
@@ -24,6 +24,7 @@ class DontIndexException(Exception):
     '''
     pass
 
+
 def _prepare_search_query(query):
     u'''Prepares the query parameters to be send to pysolr as function
     arguments.
@@ -490,7 +491,8 @@ class Indexed:
         doctype = cls._get_doctype()
         fields = cls._get_indexed_fields()
         try:
-            doc = to_indexed_doc(cls._get_before_index()(data), doctype, fields)
+            doc = to_indexed_doc(cls._get_before_index()(data),
+                                 doctype, fields)
             cls.get_index().add(cls._get_doctype(), doc)
         except DontIndexException as e:
             logger.debug('Signaled to not index this resource %s.', str(e))
@@ -518,10 +520,11 @@ class Indexed:
             index.remove(cls._get_doctype(), **idarg)
         try:
             index.add(cls._get_doctype(),
-                    to_indexed_doc(
+                      to_indexed_doc(
                         cls._get_before_index()(data),
                         cls._get_doctype(),
-                        fields))
+                        fields
+                      ))
         except DontIndexException as e:
             logger.debug('Signaled to not index this resource %s.', str(e))
 
@@ -612,7 +615,33 @@ def boost_solr_params(values):
 
 def get_fq_permission_labels(permission_labels):
     fq = '+permission_labels:'
-    fq += '(' + ' OR '.join([escape_str(label) for label in \
-        permission_labels]) +')'
+    fq += '(' + ' OR '.join([escape_str(label) for label in
+                            permission_labels]) + ')'
     return fq
-    
+
+
+def get_sort_string(model_cls, sort_str):
+    sort_by = _parse_sort_str(sort_str)
+    if not sort_by:
+        return None
+    mapping = _get_fields_mapping(model_cls.indexed)
+    sort_expr = []
+    for column, order in sort_by:
+        column = mapping.get(column, column)
+        sort_expr.append('%s %s' % (column, order))
+
+    return ','.join(sort_expr)
+
+
+def _parse_sort_str(sort_str):
+    sort_by = []
+    for sort_field in sort_str.strip().split(','):
+        sort_field = sort_field.strip()
+        if not sort_field:
+            continue
+        expr = list(filter(lambda exp: exp and exp.strip(),
+                           sort_field.split()))
+        column = expr[0]
+        order = expr[1] if len(expr) > 1 else 'asc'
+        sort_by.append((column, order))
+    return sort_by

--- a/ckanext/knowledgehub/lib/solr.py
+++ b/ckanext/knowledgehub/lib/solr.py
@@ -608,3 +608,24 @@ def boost_solr_params(values):
     if bq:
         params['bq'] = ' + '.join(bq)
     return params
+
+
+_PERMISSION_LABEL_PREFIX = {
+    'shared_with_users': 'user-%s',
+    'shared_with_organizations': 'member-%s',
+    'shared_with_groups': 'member-group-%s',
+}
+
+def get_permission_labels(data_dict):
+    permission_labels = data_dict.get('permission_labels', [])
+
+    for field, prefix_template in _PERMISSION_LABEL_PREFIX.items():
+        if data_dict.get(field):
+            ids = [s.strip() for s in data_dict[field].strip().split(',')]
+            for id in ids:
+                if id:
+                    label = prefix_template % id
+                    if label not in permission_labels:
+                        permission_labels.append(label)
+    
+    return permission_labels

--- a/ckanext/knowledgehub/lib/util.py
+++ b/ckanext/knowledgehub/lib/util.py
@@ -101,3 +101,17 @@ class monkey_patch:
         _with_patched.__module__ = method.__module__
         _with_patched.__doc__ = method.__doc__
         return _with_patched
+
+
+def get_as_list(prop, data):
+    if prop not in data:
+        return []
+    value = data[prop]
+    if not value:
+        return []
+    if isinstance(value, list):
+        return value
+    if isinstance(value, unicode) or isinstance(value, str):
+        return map(lambda v: v.strip(),
+                   filter(lambda v: v and v.strip(), value.split(',')))
+    return []

--- a/ckanext/knowledgehub/lib/util.py
+++ b/ckanext/knowledgehub/lib/util.py
@@ -112,6 +112,10 @@ def get_as_list(prop, data):
     if isinstance(value, list):
         return value
     if isinstance(value, unicode) or isinstance(value, str):
+        if value.startswith('{') and value.endswith('}'):
+            value = value[1:-1]
+        if value.startswith('"') and value.endswith('"'):
+            value = value[1:-1]
         return map(lambda v: v.strip(),
                    filter(lambda v: v and v.strip(), value.split(',')))
     return []

--- a/ckanext/knowledgehub/logic/action/create.py
+++ b/ckanext/knowledgehub/logic/action/create.py
@@ -3,7 +3,6 @@ import datetime
 import os
 import subprocess
 import re
-import json
 
 from sqlalchemy import exc
 from psycopg2 import errorcodes as pg_errorcodes
@@ -495,7 +494,6 @@ def dashboard_create(context, data_dict):
 
     # Send notification for sharing with users
     if shared_with_users is not None:
-        shared_with_users = json.loads(shared_with_users)
         if isinstance(shared_with_users, unicode):
             shared_with_users = shared_with_users.split()
 

--- a/ckanext/knowledgehub/logic/action/create.py
+++ b/ckanext/knowledgehub/logic/action/create.py
@@ -463,7 +463,10 @@ def dashboard_create(context, data_dict):
             dashboard.datasets = ', '.join(datasets)
 
     if shared_with_users is not None:
-        dashboard.shared_with_users = shared_with_users
+        if isinstance(shared_with_users, list):
+            dashboard.shared_with_users = ','.join(shared_with_users)
+        else:
+            dashboard.shared_with_users = shared_with_users
 
     tags = data_dict.get('tags', '')
     if tags:
@@ -1447,13 +1450,15 @@ def upsert_dataset_to_hdx(context, data_dict):
             'dataset_source': hdx_newest_dataset['dataset_source'],
             'maintainer': hdx_newest_dataset['maintainer'],
             'dataset_date': hdx_newest_dataset['dataset_date'],
-            'data_update_frequency': hdx_newest_dataset['data_update_frequency'],
+            'data_update_frequency':
+                hdx_newest_dataset['data_update_frequency'],
             'license_id': hdx_newest_dataset['license_id'],
             'methodology': hdx_newest_dataset['methodology'],
             'num_resources': hdx_newest_dataset['num_resources'],
             'url': hdx_newest_dataset['url'],
             'package_creator': hdx_newest_dataset['package_creator'],
-            'relationships_as_object': hdx_newest_dataset['relationships_as_object'],
+            'relationships_as_object':
+                hdx_newest_dataset['relationships_as_object'],
             'id': hdx_newest_dataset['id'],
             'metadata_created': hdx_newest_dataset['metadata_created'],
             'archived': hdx_newest_dataset['archived'],
@@ -1462,7 +1467,8 @@ def upsert_dataset_to_hdx(context, data_dict):
             'version': hdx_newest_dataset['version'],
             'type': hdx_newest_dataset['type'],
             'total_res_downloads': hdx_newest_dataset['total_res_downloads'],
-            'pageviews_last_14_days': hdx_newest_dataset['pageviews_last_14_days'],
+            'pageviews_last_14_days':
+                hdx_newest_dataset['pageviews_last_14_days'],
             'creator_user_id': hdx_newest_dataset['creator_user_id'],
             'organization': hdx_newest_dataset['organization'],
             'num_tags': hdx_newest_dataset['num_tags'],
@@ -1471,7 +1477,8 @@ def upsert_dataset_to_hdx(context, data_dict):
             'updated_by_script': hdx_newest_dataset['updated_by_script'],
             'is_fresh': hdx_newest_dataset['is_fresh'],
             'solr_additions': hdx_newest_dataset['solr_additions'],
-            'relationships_as_subject': hdx_newest_dataset['relationships_as_subject'],
+            'relationships_as_subject':
+                hdx_newest_dataset['relationships_as_subject'],
             'is_requestdata_type': hdx_newest_dataset['is_requestdata_type'],
         }
 

--- a/ckanext/knowledgehub/logic/action/get.py
+++ b/ckanext/knowledgehub/logic/action/get.py
@@ -1617,7 +1617,9 @@ def dash_search_tag(context, data_dict):
     for dash in dash_list:
         tags = dash.get('tags')
         if tags:
-            for element in tags.split(','):
+            if isinstance(tags, str) or isinstance(tags, unicode):
+                tags = tags.split(',')
+            for element in tags:
                 if element == tag:
                     dash_id = dash.get('id')
                     result.append(dash_id)

--- a/ckanext/knowledgehub/logic/action/get.py
+++ b/ckanext/knowledgehub/logic/action/get.py
@@ -35,9 +35,9 @@ from ckanext.knowledgehub import helpers as kh_helpers
 from ckanext.knowledgehub.lib.rnn import PredictiveSearchModel
 from ckanext.knowledgehub.lib.solr import (
     ckan_params_to_solr_args,
-    get_user_permission_labels,
     get_fq_permission_labels,
 )
+from ckanext.knowledgehub.logic.auth import get_user_permission_labels
 from ckan.lib import helpers as h
 from ckan.controllers.admin import get_sysadmins
 

--- a/ckanext/knowledgehub/logic/action/update.py
+++ b/ckanext/knowledgehub/logic/action/update.py
@@ -517,13 +517,11 @@ def dashboard_update(context, data_dict):
 
     # Send notification for sharing with users
     if isinstance(existing_shared_users, unicode):
-        existing_shared_users = json.loads(existing_shared_users)
         if not isinstance(existing_shared_users, list):
             existing_shared_users = existing_shared_users.split()
 
     new_shared_users = dashboard.shared_with_users or []
     if isinstance(new_shared_users, str):
-        new_shared_users = json.loads(new_shared_users)
         if isinstance(new_shared_users, unicode):
             new_shared_users = new_shared_users.split()
 

--- a/ckanext/knowledgehub/logic/auth/__init__.py
+++ b/ckanext/knowledgehub/logic/auth/__init__.py
@@ -1,0 +1,4 @@
+from ckanext.knowledgehub.logic.auth.permissions import (
+    get_permission_labels,
+    get_user_permission_labels,
+)

--- a/ckanext/knowledgehub/logic/auth/create.py
+++ b/ckanext/knowledgehub/logic/auth/create.py
@@ -1,5 +1,8 @@
-from ckan.logic.auth.create import package_create as ckan_package_create
-from ckan.logic.auth.create import resource_create as ckan_resource_create
+from ckan.logic.auth.create import (
+    package_create as ckan_package_create,
+    resource_create as ckan_resource_create,
+    member_create as ckan_member_create,
+)
 
 
 def theme_create(context, data_dict):
@@ -135,3 +138,8 @@ def user_profile_create(context, data_dict=None):
 
 def notification_create(context, data_dict=None):
     return {'success': True}
+
+
+def member_create(context, data_dict=None):
+    return ckan_member_create(context, data_dict)
+

--- a/ckanext/knowledgehub/logic/auth/get.py
+++ b/ckanext/knowledgehub/logic/auth/get.py
@@ -156,3 +156,7 @@ def notification_list(context, data_dict=None):
 
 def notification_show(context, data_dict):
     return {'success': True}
+
+
+def get_groups_for_user(context, data_dict=None):
+    return {'success': False}

--- a/ckanext/knowledgehub/logic/auth/get.py
+++ b/ckanext/knowledgehub/logic/auth/get.py
@@ -7,7 +7,6 @@ from ckan.logic.auth.get import (
 from ckan.logic import chained_action
 
 
-
 @toolkit.auth_allow_anonymous_access
 def research_question_show(context, data_dict):
     return {'success': True}
@@ -32,29 +31,17 @@ def dashboard_show(context, data_dict):
     else:
         return {'success': False}
 
+    # The search would take into consideration the type of authenticated user
+    # in the context and will perform a search based on the pemrission labels.
+    # If this document is not found, then the user does not have a permission
+    # to access this dashboard.
     docs = toolkit.get_action('search_dashboards')(
-        {'ignore_auth': True},
+        context,
         search_query
     )
-    if docs.get('count', 0) == 1:
-        dashboard = docs['results'][0]
 
-        user = context['auth_user_obj']
-        if user.name in dashboard.get('idx_shared_with_users', []):
-            return {'success': True}
-
-        datasets_str = dashboard.get('datasets', '')
-        if datasets_str:
-            datasets = datasets_str.split(', ')
-            for dataset in datasets:
-                try:
-                    context.pop('package', None)
-                    a = toolkit.check_access(
-                        'package_show', context, {'id': dataset})
-                except toolkit.NotAuthorized:
-                    return {'success': False}
-
-            return {'success': True}
+    if docs.get('count') > 0:
+        return {'success': True}
 
     return {'success': False}
 

--- a/ckanext/knowledgehub/logic/auth/permissions.py
+++ b/ckanext/knowledgehub/logic/auth/permissions.py
@@ -53,6 +53,7 @@ def _get_all_orgs_or_groups_for_user(user_id):
                model.member_table.c.group_id == model.group_table.c.id)
     q = q.filter(model.member_table.c.table_id == user_id)
     q = q.filter(model.member_table.c.table_name == 'user')
+    q = q.filter(model.member_table.c.state == 'active')
 
     organizations, groups = [], []
 

--- a/ckanext/knowledgehub/logic/auth/permissions.py
+++ b/ckanext/knowledgehub/logic/auth/permissions.py
@@ -1,0 +1,67 @@
+u'''Helper function to manage permission labels for multiple indexed entities.
+'''
+
+from ckan import model
+from ckan.model.meta import Session
+
+
+_PERMISSION_LABEL_PREFIX = {
+    'shared_with_users': 'user-%s',
+    'shared_with_organizations': 'member-%s',
+    'shared_with_groups': 'member-%s',
+}
+
+
+def get_permission_labels(data_dict):
+    permission_labels = data_dict.get('permission_labels', [])
+
+    for field, prefix_template in _PERMISSION_LABEL_PREFIX.items():
+        if data_dict.get(field):
+            ids = [s.strip() for s in data_dict[field].strip().split(',')]
+            for id in ids:
+                if id:
+                    label = prefix_template % id
+                    if label not in permission_labels:
+                        permission_labels.append(label)
+    
+    return permission_labels
+
+
+
+
+def get_user_permission_labels(context):
+    labels = ['public']
+
+    if context.get('auth_user_obj') is not None:
+        user = context['auth_user_obj']
+        labels.append('user-%s' % user.id)
+        labels.append('creator-%s' % user.id)
+
+        organizations, groups = _get_all_orgs_or_groups_for_user(user.id)
+
+        for ids in [organizations, groups]:
+            if ids:
+                if len(ids) > 1:
+                    labels.append('member-%s' % '-'.join(ids))
+                for _id in ids:
+                    labels.append('member-%s' % _id)
+
+    return labels
+
+
+def _get_all_orgs_or_groups_for_user(user_id):
+    q = Session.query(model.Member, model.Group)
+    q = q.join(model.Group,
+               model.member_table.c.group_id == model.group_table.c.id)
+    q = q.filter(model.member_table.c.table_id == user_id)
+    q = q.filter(model.member_table.c.table_name == 'user')
+
+    organizations, groups = [], []
+
+    for _,group in q.all():
+        if group.is_organization:
+            organizations.append(group.id)
+        else:
+            groups.append(group.id)
+    
+    return (organizations, groups)

--- a/ckanext/knowledgehub/logic/auth/permissions.py
+++ b/ckanext/knowledgehub/logic/auth/permissions.py
@@ -23,10 +23,8 @@ def get_permission_labels(data_dict):
                     label = prefix_template % id
                     if label not in permission_labels:
                         permission_labels.append(label)
-    
+
     return permission_labels
-
-
 
 
 def get_user_permission_labels(context):
@@ -42,7 +40,7 @@ def get_user_permission_labels(context):
         for ids in [organizations, groups]:
             if ids:
                 if len(ids) > 1:
-                    labels.append('member-%s' % '-'.join(ids))
+                    labels.append('member-%s' % '-'.join(sorted(ids)))
                 for _id in ids:
                     labels.append('member-%s' % _id)
 
@@ -58,10 +56,10 @@ def _get_all_orgs_or_groups_for_user(user_id):
 
     organizations, groups = [], []
 
-    for _,group in q.all():
+    for _, group in q.all():
         if group.is_organization:
             organizations.append(group.id)
         else:
             groups.append(group.id)
-    
-    return (organizations, groups)
+
+    return (sorted(organizations), sorted(groups))

--- a/ckanext/knowledgehub/model/dashboard.py
+++ b/ckanext/knowledgehub/model/dashboard.py
@@ -23,8 +23,8 @@ from ckanext.knowledgehub.lib.solr import (
     Indexed,
     mapped,
     unprefixed,
-    get_permission_labels,
 )
+from ckanext.knowledgehub.logic.auth import get_permission_labels
 from logging import getLogger
 
 

--- a/ckanext/knowledgehub/model/dashboard.py
+++ b/ckanext/knowledgehub/model/dashboard.py
@@ -204,9 +204,9 @@ class Dashboard(DomainObject, Indexed):
             if pkg.get('organization'):
                 org = pkg['organization']
                 organizations[org['id']] = org
-            if pkg.get('group'):
-                group = pkg['group']
-                groups[group['id']] = group
+            if pkg.get('groups'):
+                for group in pkg['groups']:
+                    groups[group['id']] = group
 
         # Set data
         data['datasets'] = ','.join(datasets.keys())

--- a/ckanext/knowledgehub/model/research_question.py
+++ b/ckanext/knowledgehub/model/research_question.py
@@ -82,6 +82,17 @@ class ResearchQuestion(DomainObject, Indexed):
     ]
 
     @classmethod
+    def get_by_id_name_or_title(cls, id_name_title):
+        query = Session.query(cls).filter(
+            or_(
+                research_question.c.id == id_name_title,
+                research_question.c.name == id_name_title,
+                research_question.c.title == id_name_title,
+            )
+        )
+        return query.first()
+
+    @classmethod
     def get(cls, id_or_name=None, **kwargs):
         q = kwargs.get('q')
         limit = kwargs.get('limit')
@@ -114,7 +125,6 @@ class ResearchQuestion(DomainObject, Indexed):
 
         if offset:
             query = query.offset(offset)
-
         return query
 
     @classmethod

--- a/ckanext/knowledgehub/model/visualization.py
+++ b/ckanext/knowledgehub/model/visualization.py
@@ -29,6 +29,7 @@ class Visualization(ResourceView, Indexed):
         unprefixed('idx_keywords'),
         unprefixed('idx_tags'),
         unprefixed('idx_research_questions'),
+        unprefixed('permission_labels'),
     ]
 
     doctype = 'visualization'
@@ -38,6 +39,8 @@ class Visualization(ResourceView, Indexed):
         # Index only charts
         if data.get('view_type') not in  ['chart', 'map']:
             raise DontIndexException(data.get('id'))
+
+        permission_labels = []
 
         resource_view = get_action('resource_view_show')(
             {'ignore_auth': True},
@@ -49,10 +52,14 @@ class Visualization(ResourceView, Indexed):
             {'id': data['package_id'], 'include_tracking': True})
         if package:
             data['organizations'] = package.get('organization', {}).get('name')
+            organization_id = package.get('organization', {}).get('id')
+            if organization_id:
+                permission_labels.append('member-%s' % organization_id)
 
             data['groups'] = []
             for g in package.get('groups', []):
                 data['groups'].append(g['name'])
+                permission_labels.append('member-%s' % g['id'])
 
         if data.get('_sa_instance_state'):
             del data['_sa_instance_state']
@@ -129,6 +136,9 @@ class Visualization(ResourceView, Indexed):
         if keywords:
             data['keywords'] = ','.join(keywords)
             data['idx_keywords'] = list(keywords)
+
+        if permission_labels:
+            data['permission_labels'] = permission_labels
 
         return data
 

--- a/ckanext/knowledgehub/plugin.py
+++ b/ckanext/knowledgehub/plugin.py
@@ -34,6 +34,7 @@ from ckanext.knowledgehub.helpers import _register_blueprints
 from ckanext.knowledgehub.lib.search import patch_ckan_core_search
 from ckanext.knowledgehub.model.keyword import extend_tag_table
 from ckanext.knowledgehub.model.visualization import extend_resource_view_table
+from ckanext.knowledgehub.model.dashboard import dashboard_table_upgrade
 from ckanext.knowledgehub.lib.util import get_as_list
 
 from ckanext.datastore.backend import (
@@ -75,6 +76,8 @@ class KnowledgehubPlugin(plugins.SingletonPlugin, DefaultDatasetForm,
         extend_tag_table()
         # Extend CKAN ResourceView table
         extend_resource_view_table()
+        # Upgrade the dashboard table.
+        dashboard_table_upgrade()
 
         DatastoreBackend.register_backends()
         # DatastoreBackend.set_active_backend(config)

--- a/ckanext/knowledgehub/plugin.py
+++ b/ckanext/knowledgehub/plugin.py
@@ -169,6 +169,8 @@ class KnowledgehubPlugin(plugins.SingletonPlugin, DefaultDatasetForm, DefaultPer
             'get_datasets': h.get_datasets,
             'get_notifications': h.get_notifications,
             'get_all_users': h.get_all_users,
+            'get_all_organizations': h.get_all_organizations,
+            'get_all_groups': h.get_all_groups,
         }
 
     # IDatasetForm

--- a/ckanext/knowledgehub/plugin.py
+++ b/ckanext/knowledgehub/plugin.py
@@ -27,6 +27,7 @@ from ckanext.datastore.backend.postgres import insert_data
 from ckanext.datastore.backend.postgres import create_indexes
 from ckanext.datastore.backend.postgres import create_alias
 from ckanext.datastore.backend.postgres import _unrename_json_field
+from ckanext.datastore.backend.postgres import _guess_type
 
 import ckanext.knowledgehub.helpers as h
 from ckanext.knowledgehub.helpers import _register_blueprints

--- a/ckanext/knowledgehub/templates/dashboard/snippets/dashboard_form.html
+++ b/ckanext/knowledgehub/templates/dashboard/snippets/dashboard_form.html
@@ -109,7 +109,7 @@
           <div class="controls">
             <select id="field_shared_with_users" name="shared_with_users" data-module="autocomplete" multiple=False>
               {% for user in users  %}
-              <option value="{{ user.name }}" {% if user.name in data.get('shared_with_users', []) %} selected="selected"
+              <option value="{{ user.name }}" {% if user.name in (data.get('shared_with_users') or []) %} selected="selected"
                 {% endif %}>{{ user.display_name }}</option>
               {% endfor %}
             </select>
@@ -122,7 +122,7 @@
             <select id="field_shared_with_organizations" name="shared_with_organizations" data-module="autocomplete" multiple=False>
               {% for organization in organizations  %}
               <option value="{{ organization.id }}"
-                {% if data.shared_with_organizations and organization.id in data.get('shared_with_organizations', []) %} selected="selected" {% endif %} >
+                {% if data.shared_with_organizations and organization.id in (data.get('shared_with_organizations') or []) %} selected="selected" {% endif %} >
                 {{ organization.title }}</option>
               {% endfor %}
             </select>
@@ -135,7 +135,7 @@
             <select id="field_shared_with_groups" name="shared_with_groups" data-module="autocomplete" multiple=False>
               {% for group in groups  %}
               <option value="{{ group.id }}"
-                {% if data.shared_with_groups and group.id in data.get('shared_with_groups', []) %} selected="selected" {% endif %} >
+                {% if data.shared_with_groups and group.id in (data.get('shared_with_groups') or []) %} selected="selected" {% endif %} >
                 {{ group.title }}</option>
               {% endfor %}
             </select>

--- a/ckanext/knowledgehub/templates/dashboard/snippets/dashboard_form.html
+++ b/ckanext/knowledgehub/templates/dashboard/snippets/dashboard_form.html
@@ -115,6 +115,34 @@
             </select>
           </div>
         </div>
+        {% set organizations = h.get_all_organizations()%}
+        <div class="control-group">
+          <label class="control-label" for="field_shared_with_organizations">{{ _("Functional Units") }}</label>
+          <div class="controls">
+            <select id="field_shared_with_organizations" name="shared_with_organizations" data-module="autocomplete" multiple=False>
+              {% for organization in organizations  %}
+              <option value="{{ organization.id }}"
+                {% if data.shared_with_organizations and organization.id in data.get('shared_with_organizations', []) %} selected="selected" {% endif %} >
+                {{ organization.title }}</option>
+              {% endfor %}
+            </select>
+          </div>
+        </div>
+        {% set groups = h.get_all_groups()%}
+        <div class="control-group">
+          <label class="control-label" for="field_shared_with_groups">{{ _("Joint Analyses") }}</label>
+          <div class="controls">
+            <select id="field_shared_with_groups" name="shared_with_groups" data-module="autocomplete" multiple=False>
+              {% for group in groups  %}
+              <option value="{{ group.id }}"
+                {% if data.shared_with_groups and group.id in data.get('shared_with_groups', []) %} selected="selected" {% endif %} >
+                {{ group.title }}</option>
+              {% endfor %}
+            </select>
+          </div>
+        </div>
+        
+
       </section>
     {% endblock %}
   {% endblock %}

--- a/ckanext/knowledgehub/templates/package/snippets/package_metadata_fields.html
+++ b/ckanext/knowledgehub/templates/package/snippets/package_metadata_fields.html
@@ -47,8 +47,32 @@
     <div class="controls">
       <select id="field_shared_with_users" name="shared_with_users" data-module="autocomplete" multiple=False>
         {% for user in users  %}
-        <option value="{{ user.name }}" {% if user.name in data.get('shared_with_users', []) %} selected="selected"
+        <option value="{{ user.name }}" {% if user.name in (data.get('shared_with_users') or []) %} selected="selected"
           {% endif %}>{{ user.display_name }}</option>
+        {% endfor %}
+      </select>
+    </div>
+  </div>
+  {% set organizations = h.get_all_organizations()%}
+  <div class="control-group">
+    <label class="control-label" for="field_shared_with_organizations">{{ _("Functional Units") }}</label>
+    <div class="controls">
+      <select id="field_shared_with_organizations" name="shared_with_organizations" data-module="autocomplete" multiple=False>
+        {% for organization in organizations  %}
+        <option value="{{ organization.id }}" {% if organization.id in (data.get('shared_with_organizations') or []) %} selected="selected"
+          {% endif %}>{{ organization.title }}</option>
+        {% endfor %}
+      </select>
+    </div>
+  </div>
+  {% set groups = h.get_all_groups()%}
+  <div class="control-group">
+    <label class="control-label" for="field_shared_with_groups">{{ _("Joint Analyses") }}</label>
+    <div class="controls">
+      <select id="field_shared_with_groups" name="shared_with_groups" data-module="autocomplete" multiple=False>
+        {% for group in groups  %}
+        <option value="{{ group.id }}" {% if group.id in (data.get('shared_with_groups') or []) %} selected="selected"
+          {% endif %}>{{ group.title }}</option>
         {% endfor %}
       </select>
     </div>

--- a/ckanext/knowledgehub/tests/test_helpers.py
+++ b/ckanext/knowledgehub/tests/test_helpers.py
@@ -11,6 +11,7 @@ from ckan.tests import helpers
 from ckan.plugins import toolkit as toolkit
 from ckan import model
 from ckan.common import g
+from collections import namedtuple
 
 from ckanext.knowledgehub.model.theme import theme_db_setup
 from ckanext.knowledgehub.model.research_question import (
@@ -415,6 +416,7 @@ class TestKWHHelpers(ActionsBase):
         assert_equals(total, 1)
 
     @monkey_patch(Dashboard, 'add_to_index', mock.Mock())
+    @monkey_patch(Dashboard, 'search_index', mock.Mock())
     def test_get_dashboards(self):
         user = factories.Sysadmin()
         context = {
@@ -433,9 +435,13 @@ class TestKWHHelpers(ActionsBase):
         }
         dashboard = create_actions.dashboard_create(context, data_dict)
 
+        _Docs = namedtuple('_Docs', ['docs', 'hits'])
+        Dashboard.search_index.return_value = _Docs([data_dict], 1)
+
         dashboards = kwh_helpers.get_dashboards(ctx=context)
 
         assert_equals(len(dashboards), 1)
+        assert_equals(Dashboard.search_index.call_count, 1)
 
     def test_remove_space_for_url(self):
         url = 'http://host:port/lang/data set'

--- a/ckanext/knowledgehub/views/dashboard.py
+++ b/ckanext/knowledgehub/views/dashboard.py
@@ -31,6 +31,7 @@ dashboard = Blueprint(
     url_prefix=u'/dashboards'
 )
 
+
 def _get_context():
     return dict(model=model, user=g.user,
                 auth_user_obj=g.userobj,
@@ -74,6 +75,9 @@ def index():
     global_results = get_action(u'dashboard_list')(context,
                                                    data_dict_global_results)
 
+    context.pop('ignore_auth', None)
+    context.pop('__auth_user_obj_checked', None)
+
     page_results = get_action(u'dashboard_list')(context,
                                                  data_dict_page_results)
 
@@ -111,7 +115,9 @@ def view(name):
         for ind in dashboard_dict['indicators']:
             res_view_id = ind.get('resource_view_id')
             if res_view_id:
-                res_view = get_action('resource_view_show')({'ignore_auth': True}, {
+                res_view = get_action('resource_view_show')({
+                    'ignore_auth': True
+                }, {
                     'id': res_view_id
                 })
                 ind['resource_view'] = res_view
@@ -181,7 +187,7 @@ class CreateView(MethodView):
 
             shared_with_users = data_dict.get('shared_with_users')
             if shared_with_users:
-                data_dict['shared_with_users'] = json.dumps(shared_with_users)
+                data_dict['shared_with_users'] = shared_with_users
 
             if data_dict.get('type') == 'internal':
                 indicators = []
@@ -192,8 +198,10 @@ class CreateView(MethodView):
                         id = k.split('_')[-1]
 
                         item['order'] = int(id)
-                        item['research_question'] = data_dict['research_question_{}'.format(id)]
-                        item['resource_view_id'] = data_dict['visualization_{}'.format(id)]
+                        item['research_question'] = \
+                            data_dict['research_question_{}'.format(id)]
+                        item['resource_view_id'] = \
+                            data_dict['visualization_{}'.format(id)]
                         item['size'] = data_dict['size_{}'.format(id)]
 
                         indicators.append(item)
@@ -228,22 +236,32 @@ class CreateView(MethodView):
 
                 for ind in data_dict['indicators']:
                     res_view_id = ind.get('resource_view_id')
-                    res_view = get_action('resource_view_show')(_get_context(), {
-                        'id': res_view_id
-                    })
+                    res_view = get_action('resource_view_show')(
+                        _get_context(),
+                        {
+                            'id': res_view_id
+                        })
                     ind['resource_view'] = res_view
 
                     rq = get_action('research_question_show')(_get_context(), {
                         'id': ind['research_question']
                     })
 
-                    viz_options = [{'text': 'Choose visualization', 'value': ''}]
-                    visualizations = get_action('visualizations_for_rq')(_get_context(), {
-                        'research_question': rq['title']
-                    })
+                    viz_options = [{
+                        'text': 'Choose visualization',
+                        'value': '',
+                    }]
+                    visualizations = get_action('visualizations_for_rq')(
+                        _get_context(),
+                        {
+                            'research_question': rq['title']
+                        })
 
                     for viz in visualizations:
-                        viz_options.append({'text': viz.get('title'), 'value': viz.get('id')})
+                        viz_options.append({
+                            'text': viz.get('title'),
+                            'value': viz.get('id'),
+                        })
 
                     ind['viz_options'] = viz_options
 
@@ -287,20 +305,17 @@ class EditView(MethodView):
         dashboard = data
         errors = errors or {}
 
-        if data.get('shared_with_users'):
-            data['shared_with_users'] = json.loads(data['shared_with_users'])
-        else:
-            data['shared_with_users'] = []
-
         if data.get('type') == 'internal':
             data['indicators'] = json.loads(data['indicators'])
 
             for ind in data['indicators']:
                 res_view_id = ind.get('resource_view_id')
                 if res_view_id:
-                    res_view = get_action('resource_view_show')(_get_context(), {
-                        'id': res_view_id
-                    })
+                    res_view = get_action('resource_view_show')(
+                        _get_context(),
+                        {
+                            'id': res_view_id
+                        })
                     ind['resource_view'] = res_view
 
                 rq = get_action('research_question_show')(_get_context(), {
@@ -308,12 +323,17 @@ class EditView(MethodView):
                 })
 
                 viz_options = [{'text': 'Choose visualization', 'value': ''}]
-                visualizations = get_action('visualizations_for_rq')(_get_context(), {
-                    'research_question': rq['title']
-                })
+                visualizations = get_action('visualizations_for_rq')(
+                    _get_context(),
+                    {
+                        'research_question': rq['title']
+                    })
 
                 for viz in visualizations:
-                    viz_options.append({'text': viz.get('title'), 'value': viz.get('id')})
+                    viz_options.append({
+                        'text': viz.get('title'),
+                        'value': viz.get('id'),
+                    })
 
                 ind['viz_options'] = viz_options
         else:
@@ -340,7 +360,7 @@ class EditView(MethodView):
 
             shared_with_users = data_dict.get('shared_with_users')
             if shared_with_users:
-                data_dict['shared_with_users'] = json.dumps(shared_with_users)
+                data_dict['shared_with_users'] = shared_with_users
 
             if data_dict.get('type') == 'internal':
                 indicators = []
@@ -351,8 +371,10 @@ class EditView(MethodView):
                         id = k.split('_')[-1]
 
                         item['order'] = int(id)
-                        item['research_question'] = data_dict['research_question_{}'.format(id)]
-                        item['resource_view_id'] = data_dict['visualization_{}'.format(id)]
+                        item['research_question'] = \
+                            data_dict['research_question_{}'.format(id)]
+                        item['resource_view_id'] = \
+                            data_dict['visualization_{}'.format(id)]
                         item['size'] = data_dict['size_{}'.format(id)]
 
                         indicators.append(item)
@@ -388,22 +410,34 @@ class EditView(MethodView):
 
                 for ind in data_dict['indicators']:
                     res_view_id = ind.get('resource_view_id')
-                    res_view = get_action('resource_view_show')(_get_context(), {
-                        'id': res_view_id
-                    })
+                    res_view = get_action('resource_view_show')(
+                        _get_context(),
+                        {
+                            'id': res_view_id
+                        })
                     ind['resource_view'] = res_view
 
-                    rq = get_action('research_question_show')(_get_context(), {
-                        'id': ind['research_question']
-                    })
+                    rq = get_action('research_question_show')(
+                        _get_context(),
+                        {
+                            'id': ind['research_question']
+                        })
 
-                    viz_options = [{'text': 'Choose visualization', 'value': ''}]
-                    visualizations = get_action('visualizations_for_rq')(_get_context(), {
-                        'research_question': rq['title']
-                    })
+                    viz_options = [{
+                        'text': 'Choose visualization',
+                        'value': ''
+                    }]
+                    visualizations = get_action('visualizations_for_rq')(
+                        _get_context(),
+                        {
+                            'research_question': rq['title']
+                        })
 
                     for viz in visualizations:
-                        viz_options.append({'text': viz.get('title'), 'value': viz.get('id')})
+                        viz_options.append({
+                            'text': viz.get('title'),
+                            'value': viz.get('id'),
+                        })
 
                     ind['viz_options'] = viz_options
 

--- a/ckanext/knowledgehub/views/dashboard.py
+++ b/ckanext/knowledgehub/views/dashboard.py
@@ -254,7 +254,7 @@ class CreateView(MethodView):
                     visualizations = get_action('visualizations_for_rq')(
                         _get_context(),
                         {
-                            'research_question': rq['title']
+                            'research_question': rq['id']
                         })
 
                     for viz in visualizations:
@@ -326,7 +326,7 @@ class EditView(MethodView):
                 visualizations = get_action('visualizations_for_rq')(
                     _get_context(),
                     {
-                        'research_question': rq['title']
+                        'research_question': rq['id']
                     })
 
                 for viz in visualizations:
@@ -430,7 +430,7 @@ class EditView(MethodView):
                     visualizations = get_action('visualizations_for_rq')(
                         _get_context(),
                         {
-                            'research_question': rq['title']
+                            'research_question': rq['id']
                         })
 
                     for viz in visualizations:


### PR DESCRIPTION
Brings the following features:
* Share Dashboard with specific organizations (makes it available read-only for all members in the organization)
* Share Dashboard with specific groups (makes it available read-only for all members in the group)
* Share a Dataset with specific organizations
* Share a Dataset with specific groups
* Extends the permission-label ACL security of CKAN for datasets (so to accommodate the sharing of the dataset with groups/organizations which do not have access to that dataset)
* Adds permission-label based ACL to Dashboards
* Adds notifications for all users which get access (or to which the access is revoked) when a dataset/dashboard is revoked. The notifications are the internal portal notification via the notifications system.