### PR TITLE
Fixes the way shared_with_users is kept and Dashboard indexing of dataset shared users permissions.

### DIFF
--- a/ckanext/knowledgehub/logic/action/create.py
+++ b/ckanext/knowledgehub/logic/action/create.py
@@ -572,9 +572,19 @@ def dashboard_create(context, data_dict):
 
 
 def package_create(context, data_dict):
+    shared_with_users = get_as_list('shared_with_users', data_dict)
+    shared_with_groups = get_as_list('shared_with_groups', data_dict)
+    shared_with_organizations = get_as_list('shared_with_organizations',
+                                            data_dict)
+
+    # Remap to comma separated values
+    data_dict['shared_with_users'] = ','.join(shared_with_users)
+    data_dict['shared_with_organizations'] = \
+        ','.join(shared_with_organizations)
+    data_dict['shared_with_groups'] = ','.join(shared_with_groups)
+
     dataset = ckan_package_create(context, data_dict)
 
-    shared_with_users = get_as_list('shared_with_users', data_dict)
     if shared_with_users:
         plugin_helpers.shared_with_users_notification(
             context['auth_user_obj'],
@@ -592,10 +602,6 @@ def package_create(context, data_dict):
                     'type': 'package',
                     'package': dataset,
                 })
-
-    shared_with_groups = get_as_list('shared_with_groups', data_dict)
-    shared_with_organizations = get_as_list('shared_with_organizations',
-                                            data_dict)
 
     plugin_helpers.notification_broadcast({
         'ignore_auth': True,

--- a/ckanext/knowledgehub/logic/action/update.py
+++ b/ckanext/knowledgehub/logic/action/update.py
@@ -693,6 +693,11 @@ def package_update(context, data_dict):
                 str(e)
             ))
 
+    # Remap values to data_dict
+    data_dict['shared_with_users'] = ','.join(new_shared_users)
+    data_dict['shared_with_organizations'] = ','.join(shared_with_orgs)
+    data_dict['shared_with_groups'] = ','.join(shared_with_groups)
+
     result = ckan_package_update(context, data_dict)
     schedule_data_quality_check(result['id'])
 

--- a/ckanext/knowledgehub/model/dashboard.py
+++ b/ckanext/knowledgehub/model/dashboard.py
@@ -344,10 +344,10 @@ class Dashboard(DomainObject, Indexed):
         # dashboard as well to add access to those users to this dataset.
         shared_users = []
         for _, dataset in datasets.items():
+            user_with_access = set()
             if dataset.get('shared_with_users'):
                 shared_with = cls._get_safe_shared_with(
                     dataset['shared_with_users'])
-                user_with_access = set()
                 for user_id in map(lambda u: u.strip(),
                                    filter(lambda u: u and u.strip(),
                                           shared_with.split(','))):
@@ -356,10 +356,10 @@ class Dashboard(DomainObject, Indexed):
                     if user:
                         user_with_access.add(user['id'])
 
-                shared_users.append(user_with_access)
+            shared_users.append(user_with_access)
 
         if shared_users:
-            if len(shared_users) == 1:
+            if len(datasets) == 1:
                 for user_id in shared_users[0]:
                     permission_labels.append('user-%s' % user_id)
             else:


### PR DESCRIPTION
Fixes the way the value of `shared_with_*` properties is processed and used.
Fixes the generation of permission roles for Dashboard when users that have explicit access to datasets (dataset is shared with exact users) have access to ALL datasets from which a dashboard draws its data.