### PR TITLE
Fixes access issues with the news feed - all users should be able to see all news in the feed.

### DIFF
--- a/ckanext/knowledgehub/controllers/package.py
+++ b/ckanext/knowledgehub/controllers/package.py
@@ -546,7 +546,7 @@ class KWHPackageController(PackageController):
         except NotFound:
             abort(404, _('Dataset not found'))
         except NotAuthorized:
-            abort(403, _('Not authorize to see the page'))
+            abort(403, _('Not authorized to see the page'))
 
         # used by disqus plugin
         c.current_package_id = c.pkg.id

--- a/ckanext/knowledgehub/logic/action/get.py
+++ b/ckanext/knowledgehub/logic/action/get.py
@@ -2232,6 +2232,9 @@ def post_search(context, data_dict):
     if 'sort' in data_dict:
         data_dict['sort'] = get_sort_string(Posts, data_dict['sort'])
 
+    # Ignore permissions label, because everyone should be able to see posts.
+    data_dict['ignore_permissions'] = True
+
     posts = _search_entity(Posts, context, data_dict)
 
     if data_dict.get('with_entity', True):

--- a/ckanext/knowledgehub/logic/auth/delete.py
+++ b/ckanext/knowledgehub/logic/auth/delete.py
@@ -72,3 +72,7 @@ def package_delete(context, data_dict):
     otherwise a recursion error is thrown.
     '''
     return ckan_package_delete(context, data_dict)
+
+
+def post_delete(context, data_dict=None):
+    return {'success': True}

--- a/ckanext/knowledgehub/templates/research_question/read.html
+++ b/ckanext/knowledgehub/templates/research_question/read.html
@@ -15,8 +15,8 @@
 {% block subtitle %}{{ h.dataset_display_name(rq) }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
 
 {% block content_action %}
-{% if h.check_access('research_question_update') %}
 {% link_for _('Post to news feed'), named_route='news.new', entity_ref=rq.id, entity_type='research_question', class_='btn btn-default', icon='share-square' %}
+{% if h.check_access('research_question_update') %}
 {% link_for _('Manage'), named_route='research_question.edit', name=rq.name, class_='btn btn-default', icon='wrench' %}
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
Fixes the problems with loading and adding news feeds when the user has regular `member` role in the system:
 * All posts are now visible for every user
 * Every user can create a post from Dataset/Dashboard/Research Question/Visualization the is accessible. 