### PR TITLE
Fix for error 500 on news feed page

### DIFF
--- a/ckanext/knowledgehub/controllers/package.py
+++ b/ckanext/knowledgehub/controllers/package.py
@@ -546,7 +546,7 @@ class KWHPackageController(PackageController):
         except NotFound:
             abort(404, _('Dataset not found'))
         except NotAuthorized:
-            abort(403, _('Not authorize to see the page'))
+            abort(403, _('Not authorized to see the page'))
 
         # used by disqus plugin
         c.current_package_id = c.pkg.id

--- a/ckanext/knowledgehub/logic/action/get.py
+++ b/ckanext/knowledgehub/logic/action/get.py
@@ -2232,6 +2232,9 @@ def post_search(context, data_dict):
     if 'sort' in data_dict:
         data_dict['sort'] = get_sort_string(Posts, data_dict['sort'])
 
+    # Ignore permissions label, because everyone should be able to see posts.
+    data_dict['ignore_permissions'] = True
+
     posts = _search_entity(Posts, context, data_dict)
 
     if data_dict.get('with_entity', True):

--- a/ckanext/knowledgehub/logic/auth/delete.py
+++ b/ckanext/knowledgehub/logic/auth/delete.py
@@ -72,3 +72,7 @@ def package_delete(context, data_dict):
     otherwise a recursion error is thrown.
     '''
     return ckan_package_delete(context, data_dict)
+
+
+def post_delete(context, data_dict=None):
+    return {'success': True}

--- a/ckanext/knowledgehub/templates/news/snippets/post.html
+++ b/ckanext/knowledgehub/templates/news/snippets/post.html
@@ -29,9 +29,26 @@
     </div>
     {% endif %}
     {% if post.entity_type and post.entity_ref %}
-    <div class="newsfeed-box row">
-      {% snippet 'news/snippets/entity_preview.html', post=post %}
-    </div>
+      {% if post.get('entity_deleted') or post.get('entity_error')%}
+      <div class="newsfeed-box row">
+        <ul class="newsfeed-list list-unstyled">
+          <li class="">
+            <div class="alert alert-danger">
+              <i class="fa fa-minus-circle"></i>
+              {% if post.get('entity_deleted') %}
+              {{ _('Related {} was deleted.'.format(post.entity_type)) }}
+              {% else %}
+              {{ _('An error occured while displaying this content.') }}
+              {% endif %}
+            </div>
+          </li>
+        </ul>
+      </div>
+      {% else %}
+        <div class="newsfeed-box row">
+          {% snippet 'news/snippets/entity_preview.html', post=post %}
+        </div>
+      {% endif %}
     {% endif %}
     <p>{{h.render_markdown(post.description)}}</p>
     <p>

--- a/ckanext/knowledgehub/templates/research_question/read.html
+++ b/ckanext/knowledgehub/templates/research_question/read.html
@@ -15,8 +15,8 @@
 {% block subtitle %}{{ h.dataset_display_name(rq) }} {{ g.template_title_delimiter }} {{ super() }}{% endblock %}
 
 {% block content_action %}
-{% if h.check_access('research_question_update') %}
 {% link_for _('Post to news feed'), named_route='news.new', entity_ref=rq.id, entity_type='research_question', class_='btn btn-default', icon='share-square' %}
+{% if h.check_access('research_question_update') %}
 {% link_for _('Manage'), named_route='research_question.edit', name=rq.name, class_='btn btn-default', icon='wrench' %}
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
Fixes errors on the newsfeed page when the related entities are not available because they are deleted or an unexpected error occurs during fetch,