### PR TITLE
Feature: request access to data

### DIFF
--- a/ckanext/knowledgehub/fanstatic/javascript/access_requests.js
+++ b/ckanext/knowledgehub/fanstatic/javascript/access_requests.js
@@ -1,0 +1,94 @@
+(function (_, $) {
+
+    function confimationModal(selector, onYes, onNo) {
+        var modal = $(selector);
+        modal.modal({
+            'show': true
+        })
+        $('#btnYes', modal).on('click', function(){
+            if(onYes){
+                onYes()
+            }
+            modal.modal('hide');
+        })
+        $('#btnNo', modal).on('click', function(){
+            if(onNo){
+                onNo()
+            }
+            modal.modal('hide');
+        })
+    }
+
+    $(function(){
+        var table = $('#access_requests').DataTable({
+            paging: true,
+            search: false,
+            serverSide: true,
+            ordering: false,
+            iDisplayLength: 25,
+            columns: [{
+                data: "requested"
+            }, {
+                data: "entity_type",
+            }, {
+                data: "requested_by"
+            }, {
+                data: 'requested_at'
+            }, {
+                data: "actions"
+            }],
+            ajax: {
+                url: '/api/3/action/access_request_list',
+                method: 'POST',
+                data: function(data) {
+                    return {
+                        'page': data.start/data.length + 1,
+                        'limit': data.length,
+                        'search': data.search ? data.search.value : ''
+                    };
+                },
+                dataSrc: function(data) {
+                    var results = data.result.results.map(function(record) {
+                        record.requested = [
+                            '<a href="', record.entity_link, '">',
+                            record.entity_title, '</a>'].join('');
+                        record.requested_by = record.user.full_name
+                        record.actions = [
+                            '<div class="btn-group pull-right">',
+                                '<button class="btn btn-primary action-access-request-grant" ',
+                                'href="', record.grant_url ,'">',
+                                    '<i class="fa fa-plus"></i>',
+                                    _('Grant Access'),
+                                '</button>',
+                                '<button class="btn btn-danger action-access-request-decline"',
+                                'href="', record.decline_url ,'">',
+                                    '<i class="fa fa-trash"></i>',
+                                    _('Decline'),
+                                '</button>',
+                            '</div>'
+                        ].join('')
+                        record.requested_at = moment(record.created_at).format('lll')
+                        return record;
+                    });
+                    return results;
+                }
+            }
+        });
+        table.on('xhr', function(ev, settings, resp){
+            if(resp.result) {
+                resp.recordsTotal = resp.result.count;
+                resp.recordsFiltered = resp.result.count;
+            }
+        })
+        $(document).on('click', '.action-access-request-grant', function(){
+            confimationModal('#modalGrant', function(){
+                window.location = $(this).attr('href');
+            }.bind(this))
+        })
+        $(document).on('click', '.action-access-request-decline', function(){
+            confimationModal('#modalDecline', function(){
+                window.location = $(this).attr('href');
+            }.bind(this))
+        })
+    });
+})(ckan.i18n.ngettext, $);

--- a/ckanext/knowledgehub/helpers.py
+++ b/ckanext/knowledgehub/helpers.py
@@ -1734,10 +1734,13 @@ def human_elapsed_time(dt):
 
 
 def get_requested_resource_type_and_ref():
-    if 'pylons.original_request' not in request.environ:
-        raise Exception('Cannot determine original request.')
+    if 'pylons.original_request' in request.environ:
+        path = request.environ['pylons.original_request'].path_qs
+    else:
+        path = request.path
 
-    path = request.environ['pylons.original_request'].path_qs
+    if not path:
+        return None
 
     patterns = {
         'dataset': r'^/dataset/(?P<ref>[^/]+)$',

--- a/ckanext/knowledgehub/helpers.py
+++ b/ckanext/knowledgehub/helpers.py
@@ -1727,3 +1727,28 @@ def human_elapsed_time(dt):
     if isinstance(dt, str) or isinstance(dt, unicode):
         dt = parser.parse(dt)
     return humanize.naturaltime(now - dt)
+
+
+def get_requested_resource_type_and_ref():
+    if 'pylons.original_request' not in request.environ:
+        raise Exception('Cannot determine original request.')
+
+    path = request.environ['pylons.original_request'].path_qs
+
+    patterns = {
+        'dataset': r'^/dataset/(?P<ref>[^/]+)$',
+        'dashboard': r'^/dashboards/(?P<ref>[^/]+)/view$',
+        'visualization':
+            r'^/dataset/[^/]+/resource/[^/]+$\?view_id=(?P<ref>[a-f0-9\-]+)',
+    }
+
+    for entity_type, pattern in patterns.items():
+        match = re.match(pattern, path)
+        if match:
+            entity_ref = match.group('ref')
+            return {
+                'entity_type': entity_type,
+                'entity_ref': entity_ref,
+            }
+
+    return None

--- a/ckanext/knowledgehub/helpers.py
+++ b/ckanext/knowledgehub/helpers.py
@@ -1715,11 +1715,15 @@ def get_members(context, group_id):
 
 
 def check_if_dataset_is_on_hdx(dataset_name):
-
-    dataset = Dataset.read_from_hdx(dataset_name)
-    if not dataset:
-        return False
-    return True
+    try:
+        dataset = Dataset.read_from_hdx(dataset_name)
+        if not dataset:
+            return False
+        return True
+    except Exception as e:
+        log.error('Failed to read from HDX. Error: %s', str(e))
+        log.exception(e)
+    return False
 
 
 def human_elapsed_time(dt):

--- a/ckanext/knowledgehub/lib/intents.py
+++ b/ckanext/knowledgehub/lib/intents.py
@@ -171,6 +171,9 @@ class UserIntentsExtractor:
         }
 
     def _extract_research_question(self, query_text):
+        query_text = query_text.strip()
+        if not query_text:
+            return (None, None, None)
         results = self.research_question.search_index(q='text:' + query_text,
                                                       rows=1)
         if results.hits:

--- a/ckanext/knowledgehub/logic/action/create.py
+++ b/ckanext/knowledgehub/logic/action/create.py
@@ -1767,7 +1767,9 @@ def request_access(context, data_dict):
     entity = None
     action = entities_actions[entity_type]
     try:
-        entity = toolkit.get_action(action)(context, {
+        entity = toolkit.get_action(action)({
+            'ignore_auth': True,
+        }, {
             'id': entity_ref,
         })
     except logic.NotFound as e:
@@ -1780,7 +1782,7 @@ def request_access(context, data_dict):
     # Lookup organization admins and system admins
     organizations = set()
     if entity_type == 'dataset':
-        organizations.add(entity['organization']['id'])
+        organizations.add(entity.get('owner_org'))
     elif entity_type == 'visualization':
         try:
             dataset = toolkit.get_action('package_show')({
@@ -1795,7 +1797,7 @@ def request_access(context, data_dict):
                       'Dataset: %s. Error: %s', entity['package_id'], str(e))
             log.exception(e)
             raise e
-        organizations.add(dataset['organization']['id'])
+        organizations.add(dataset.get('owner_org'))
     elif entity_type == 'dashboard':
         datasets = entity.get('datasets', '').split(',')
         for dataset in datasets:
@@ -1816,7 +1818,7 @@ def request_access(context, data_dict):
                 log.exception(e)
                 raise e
 
-            organizations.add(dataset['organization']['id'])
+            organizations.add(dataset.get('owner_org'))
     else:
         log.warning('Entity type is %s', entity_type)
 

--- a/ckanext/knowledgehub/logic/action/create.py
+++ b/ckanext/knowledgehub/logic/action/create.py
@@ -1824,6 +1824,8 @@ def request_access(context, data_dict):
 
     users = set()
     for organization in organizations:
+        if not organization:
+            continue
         try:
             members = toolkit.get_action('member_list')({
                 'ignore_auth': True,
@@ -1909,7 +1911,7 @@ def request_access(context, data_dict):
                       str(e))
             log.exception(e)
 
-        # Send notification email approver
+        # Send notification email to approver
         try:
             schedule_notification_email(recipient, 'access_request', {
                 'entity_type': access_request.entity_type,

--- a/ckanext/knowledgehub/logic/action/create.py
+++ b/ckanext/knowledgehub/logic/action/create.py
@@ -1806,7 +1806,7 @@ def request_access(context, data_dict):
                 continue
             try:
                 dataset = toolkit.get_action('package_show')({
-                    'igore_auth': True,
+                    'ignore_auth': True,
                 }, {
                     'id': dataset,
                 })
@@ -1844,11 +1844,31 @@ def request_access(context, data_dict):
         users.add(sysadmin.id)
 
     try:
+        entity_link = None
+        if entity_type == 'dataset':
+            entity_link = url_for(
+                controller='package',
+                action='read',
+                id=entity.get('name'))
+        elif entity_type == 'visualization':
+            entity_link = url_for(
+                controller='package',
+                action='resource_read',
+                id=entity.get('package_id'),
+                resource_id=entity.get('resource_id'),
+                view_id=entity.get('id'))
+        elif entity_type == 'dashboard':
+            entity_link = url_for(
+                'dashboards.view',
+                name=entity.get('name'))
+
         model.Session.begin(subtransactions=True)
         access_request = AccessRequest(
             user_id=user.id,
             entity_type=entity_type,
             entity_ref=entity_ref,
+            entity_title=entity.get('title'),
+            entity_link=entity_link,
         )
 
         access_request.save()
@@ -1876,7 +1896,7 @@ def request_access(context, data_dict):
 
 def _find_sysadmins():
     q = model.Session.query(model.User)
-    q = q.filter(model.user_table.c.sysadmin is True)
+    q = q.filter(model.user_table.c.sysadmin == True)
     sysadmins = []
     for user in q.all():
         sysadmins.append(user)

--- a/ckanext/knowledgehub/logic/action/get.py
+++ b/ckanext/knowledgehub/logic/action/get.py
@@ -2265,6 +2265,18 @@ def post_search(context, data_dict):
 
 
 def access_request_list(context, data_dict):
+    '''Looks up the requests for access assigned to the current user.
+
+    :param page: `int`, the page of results to return (1-based).
+    :param limit: `int`, number of results per page (default 20).
+    :param requested_by: `str`, the ID of the user that created the requests
+        for access.
+    :param search: `str`, search string to match against the entity title.
+
+    :returns: `list` of `dict`, list of access requests in dict form. The
+        related entity (dataset, dashboard, resource_view) and user info for
+        each request is also populated.
+    '''
     check_access('access_request_list', context, data_dict)
 
     user = context.get('auth_user_obj')

--- a/ckanext/knowledgehub/logic/action/get.py
+++ b/ckanext/knowledgehub/logic/action/get.py
@@ -2274,6 +2274,7 @@ def access_request_list(context, data_dict):
     limit = int(data_dict.get('limit', 20))
     status = data_dict.get('status', '').lower()
     requested_by = data_dict.get('requested_by', '').strip()
+    search = data_dict.get('search', '').strip()
     offset = max(0, (page-1) * limit)
 
     count = AccessRequest.get_all_count(
@@ -2286,6 +2287,7 @@ def access_request_list(context, data_dict):
         assigned_to=user.id,
         requested_by=requested_by,
         status=status,
+        search=search,
         offset=offset,
         limit=limit,
     )
@@ -2299,6 +2301,10 @@ def access_request_list(context, data_dict):
             'full_name': requested_by.display_name or
             requested_by.full_name or requested_by.name,
         }
+        access_req['grant_url'] = h.url_for('access.grant',
+                                            id=access_req['id'])
+        access_req['decline_url'] = h.url_for('access.decline',
+                                              id=access_req['id'])
         items.append(access_req)
 
     return {

--- a/ckanext/knowledgehub/logic/action/update.py
+++ b/ckanext/knowledgehub/logic/action/update.py
@@ -1751,7 +1751,7 @@ def notifications_read(context, data_dict):
 
 def _access_request_update(context, data_dict, granted=True):
     check_access(
-        'access_request_grant' if granted else 'access_request_declined',
+        'access_request_grant' if granted else 'access_request_decline',
         context,
         data_dict
     )

--- a/ckanext/knowledgehub/logic/action/update.py
+++ b/ckanext/knowledgehub/logic/action/update.py
@@ -1866,8 +1866,24 @@ def _access_request_update(context, data_dict, granted=True):
 
 
 def access_request_grant(context, data_dict):
+    '''Grants access to the data to the user that made this access request -
+    approves the access request.
+
+    Appropriate notifications are sent to the user that created the request.
+
+    :param id: `str`, the ID of the access request.
+
+    :returns: `dict`, the dict representation of the access request.
+    '''
     return _access_request_update(context, data_dict, granted=True)
 
 
 def access_request_decline(context, data_dict):
+    '''Declines access to the data to the user that made this access request -
+    declines the access request.
+
+    :param id: `str`, the ID of the access request.
+
+    :returns: `dict`, the dict representation of the access request.
+    '''
     return _access_request_update(context, data_dict, granted=False)

--- a/ckanext/knowledgehub/logic/auth/create.py
+++ b/ckanext/knowledgehub/logic/auth/create.py
@@ -146,3 +146,7 @@ def member_create(context, data_dict=None):
 
 def post_create(context, data_dict=None):
     return {'success': True}
+
+
+def request_access(context, data_dict=None):
+    return {'success': True}

--- a/ckanext/knowledgehub/logic/auth/get.py
+++ b/ckanext/knowledgehub/logic/auth/get.py
@@ -168,3 +168,7 @@ def post_show(context, data_dict=None):
 
 def post_search(context, data_dict=None):
     return {'success': True}
+
+
+def access_request_list(context, data_dict=None):
+    return {'success': True}

--- a/ckanext/knowledgehub/logic/auth/update.py
+++ b/ckanext/knowledgehub/logic/auth/update.py
@@ -106,3 +106,11 @@ def datastore_create(action, context, data_dict=None):
 
 def notifications_read(context, data_dict):
     return {'success': True}
+
+
+def access_request_grant(context, data_dict):
+    return {'success': True}
+
+
+def access_request_decline(context, data_dict):
+    return {'success': True}

--- a/ckanext/knowledgehub/model/__init__.py
+++ b/ckanext/knowledgehub/model/__init__.py
@@ -15,9 +15,15 @@ from ckanext.knowledgehub.model.user_profile import UserProfile
 from ckanext.knowledgehub.model.keyword import Keyword, ExtendedTag
 from ckanext.knowledgehub.model.notification import Notification
 from ckanext.knowledgehub.model.posts import Posts
+from ckanext.knowledgehub.model.access_request import (
+    AccessRequest,
+    AssignedAccessRequest,
+)
 
 
 __all__ = [
+    'AccessRequest',
+    'AssignedAccessRequest',
     'Theme',
     'SubThemes',
     'ResearchQuestion',

--- a/ckanext/knowledgehub/model/access_request.py
+++ b/ckanext/knowledgehub/model/access_request.py
@@ -1,0 +1,145 @@
+import datetime
+import json
+import ast
+from itertools import product
+from sqlalchemy import (
+    types,
+    Column,
+    Table,
+    or_,
+    ForeignKey,
+    func,
+)
+from sqlalchemy.engine import reflection
+
+from ckan.model.meta import (
+    metadata,
+    mapper,
+    engine,
+    Session
+)
+from ckan.model.types import make_uuid
+from ckan.model.domain_object import DomainObject
+from ckan.logic import get_action
+import ckan.logic as logic
+from ckan.common import _
+from ckanext.knowledgehub.lib.solr import (
+    Indexed,
+    mapped,
+    unprefixed,
+)
+from ckanext.knowledgehub.logic.auth import get_permission_labels
+from ckanext.knowledgehub.lib.util import get_as_list
+from logging import getLogger
+from ckan.model import (
+    User,
+    user_table,
+)
+
+
+access_request_table = Table(
+    'access_request',
+    metadata,
+    Column('id', types.UnicodeText,
+           primary_key=True, default=make_uuid),
+    Column('user_id', types.UnicodeText, nullable=False),
+    Column('created_at', types.DateTime,
+           default=datetime.datetime.utcnow),
+    Column('modified_at', types.DateTime,
+           default=datetime.datetime.utcnow),
+    Column('entity_type', types.String(20), nullable=False),
+    Column('entity_ref', types.UnicodeText, nullable=False),
+    Column('status', types.String(20), nullable=False, default='pending'),
+    Column('resolved_by', types.UnicodeText),
+)
+
+assigned_access_requests_table = Table(
+    'assigned_access_requests',
+    metadata,
+    Column('request_id',
+           types.UnicodeText,
+           ForeignKey('access_request.id'),
+           primary_key=True),
+    Column('user_id', types.UnicodeText, primary_key=True),
+)
+
+
+class AccessRequest(DomainObject):
+
+    @classmethod
+    def get(cls, ref):
+        return Session.query(cls).get(ref)
+
+    @classmethod
+    def get_active_for_user_and_entity(cls, entity_type, entity_ref, user_id):
+        q = Session.query(cls)
+        q = q.filter(access_request_table.c.entity_type == entity_type)
+        q = q.filter(access_request_table.c.entity_ref == entity_ref)
+        q = q.filter(access_request_table.c.user_id == user_id)
+        q = q.filter(access_request_table.c.status == 'pending')
+        print q
+        return q.first()
+
+    @classmethod
+    def get_all(cls,
+                assigned_to=None,
+                requested_by=None,
+                order_by='created_at desc',
+                status='pending',
+                offset=0,
+                limit=20):
+        q = Session.query(AccessRequest, User).join(AssignedAccessRequest)
+        q = q.join(User, user_table.c.id == access_request_table.c.user_id)
+        if assigned_to:
+            q = q.filter(
+                assigned_access_requests_table.c.user_id == assigned_to)
+        if requested_by:
+            q = q.filter(access_request_table.c.user_id == requested_by)
+        if status:
+            q = q.filter(access_request_table.c.status == status)
+
+        q = q.order_by(order_by)
+        q = q.limit(limit).offset(offset)
+
+        return q.all()
+
+    @classmethod
+    def get_all_count(cls,
+                      assigned_to=None,
+                      requested_by=None,
+                      order_by='created_at desc',
+                      status='pending'):
+        q = Session.query(func.count(func.distinct(access_request_table.c.id)))
+        if assigned_to:
+            q = q.join(AssignedAccessRequest)
+            q = q.filter(
+                assigned_access_requests_table.c.user_id == assigned_to)
+        if requested_by:
+            q = q.filter(access_request_table.c.user_id == requested_by)
+        if status:
+            q = q.filter(access_request_table.c.status == status)
+
+        return q.scalar()
+
+
+class AssignedAccessRequest(DomainObject):
+
+    @classmethod
+    def get_assigned_request(cls, request_id, user_id):
+        q = Session.query(cls)
+        q = q.filter(assigned_access_requests_table.c.user_id == user_id)
+        q = q.filter(assigned_access_requests_table.c.request_id == request_id)
+
+        return q.first()
+
+    @classmethod
+    def delete_assigned_requests(cls, request_id):
+        pass
+
+
+mapper(AccessRequest, access_request_table)
+mapper(AssignedAccessRequest, assigned_access_requests_table)
+
+
+def setup():
+    metadata.create_all(engine)

--- a/ckanext/knowledgehub/plugin.py
+++ b/ckanext/knowledgehub/plugin.py
@@ -199,6 +199,8 @@ class KnowledgehubPlugin(plugins.SingletonPlugin, DefaultDatasetForm,
             'calculate_time_passed': h.calculate_time_passed,
             'check_if_dataset_is_on_hdx': h.check_if_dataset_is_on_hdx,
             'human_elapsed_time': h.human_elapsed_time,
+            'get_requested_resource_type_and_ref':
+                h.get_requested_resource_type_and_ref,
         }
 
     # IDatasetForm

--- a/ckanext/knowledgehub/templates/access/declined.html
+++ b/ckanext/knowledgehub/templates/access/declined.html
@@ -8,12 +8,16 @@
 
 {% block primary_content_inner %}
 {% set user_name = access_request.get('user', {}).get('name') or access_request.get('user_id') %}
-<div class="container-fluid">
+<div class="container">
     <div class="row">
-        <div class="col-md-12">
+        <div class="col-md-6">
             <h2>{{ _('Access Request Declined') }}</h2>
             <p>
-                {{ _('Request for access to {} to user {} has beed declined.').format(access_request.get('entity_title'), user_name) }}
+                {{ _('Request for access to ') }}
+                <a href="{{access_request.entity_link}}">{{access_request.entity_title}}</a>
+                {{ _('to user')}}
+                <a href="{{ h.url_for('/user/{}'.format(access_request.get('user', {}).get('name'))) }}">{{user_name}}</a>
+                {{ _('has beed declined.') }}
             </p>
         </div>
     </div>

--- a/ckanext/knowledgehub/templates/access/declined.html
+++ b/ckanext/knowledgehub/templates/access/declined.html
@@ -1,0 +1,26 @@
+{% extends "user/dashboard.html" %}
+
+{% block dashboard_activity_stream_context %}{% endblock %}
+
+{% block page_primary_action %}
+  
+{% endblock %}
+
+{% block primary_content_inner %}
+{% set user_name = access_request.get('user', {}).get('name') or access_request.get('user_id') %}
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-md-12">
+            <h2>{{ _('Access Request Declined') }}</h2>
+            <p>
+                {{ _('Request for access to {} to user {} has beed declined.').format(access_request.get('entity_title'), user_name) }}
+            </p>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-md-12">
+            <a href="{{ h.url_for('user_dashboard.requests_list') }}" class="btn btn-primary pull-right">{{ _('Ok') }}</a>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/ckanext/knowledgehub/templates/access/granted.html
+++ b/ckanext/knowledgehub/templates/access/granted.html
@@ -7,13 +7,16 @@
 {% endblock %}
 
 {% block primary_content_inner %}
-{% set user_name = access_request.get('user', {}).get('name') or access_request.get('user_id') %}
-<div class="container-fluid">
+{% set user_name = access_request.get('user', {}).get('display_name') or access_request.get('user_id') %}
+<div class="container">
     <div class="row">
-        <div class="col-md-12">
+        <div class="col-md-6">
             <h2>{{ _('Access Granted') }}</h2>
             <p>
-                {{ _('You have granted access to {} to user {}.').format(access_request.get('entity_title'), user_name) }}
+                {{ _('You have granted access to ') }}
+                <a href="{{access_request.entity_link}}">{{access_request.entity_title}}</a>
+                {{ _('to user')}}
+                <a href="{{ h.url_for('/user/{}'.format(access_request.get('user', {}).get('name'))) }}">{{user_name}}</a>.
             </p>
         </div>
     </div>

--- a/ckanext/knowledgehub/templates/access/granted.html
+++ b/ckanext/knowledgehub/templates/access/granted.html
@@ -1,0 +1,26 @@
+{% extends "user/dashboard.html" %}
+
+{% block dashboard_activity_stream_context %}{% endblock %}
+
+{% block page_primary_action %}
+  
+{% endblock %}
+
+{% block primary_content_inner %}
+{% set user_name = access_request.get('user', {}).get('name') or access_request.get('user_id') %}
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-md-12">
+            <h2>{{ _('Access Granted') }}</h2>
+            <p>
+                {{ _('You have granted access to {} to user {}.').format(access_request.get('entity_title'), user_name) }}
+            </p>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-md-12">
+            <a href="{{ h.url_for('user_dashboard.requests_list') }}" class="btn btn-primary pull-right">{{ _('Ok') }}</a>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/ckanext/knowledgehub/templates/access/request.html
+++ b/ckanext/knowledgehub/templates/access/request.html
@@ -1,5 +1,23 @@
 {% extends "page.html" %}
 
 {% block primary_content %}
-    REQUEST SENT
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-md-12">
+            {% if errors %}
+                <h3>{{ _('An error has occured while requesting access') }}</h3>
+                <ul>
+                    {% for err in errors %}
+                    <li>{{ err }}</li>
+                    {% endfor%}
+                </ul>
+                <a href="{{ h.url_for('/') }}" class="btn btn-primary pull-right">{{ _('OK') }}</a>
+            {% else %}
+                <h3>{{ _('Request sent') }}</h3>
+                {{ _('Your request has been successfully sent to be approved.') }}
+                <a href="{{ h.url_for('/') }}" class="btn btn-primary pull-right">{{ _('OK') }}</a>
+            {% endif%}
+        </div>
+    </div>
+</div>
 {% endblock %}

--- a/ckanext/knowledgehub/templates/access/request.html
+++ b/ckanext/knowledgehub/templates/access/request.html
@@ -1,9 +1,9 @@
 {% extends "page.html" %}
 
 {% block primary_content %}
-<div class="container-fluid">
+<div class="container">
     <div class="row">
-        <div class="col-md-12">
+        <div class="col-md-6">
             {% if errors %}
                 <h3>{{ _('An error has occured while requesting access') }}</h3>
                 <ul>

--- a/ckanext/knowledgehub/templates/access/request.html
+++ b/ckanext/knowledgehub/templates/access/request.html
@@ -1,0 +1,5 @@
+{% extends "page.html" %}
+
+{% block primary_content %}
+    REQUEST SENT
+{% endblock %}

--- a/ckanext/knowledgehub/templates/access/requests_list.html
+++ b/ckanext/knowledgehub/templates/access/requests_list.html
@@ -1,0 +1,82 @@
+{% resource 'knowledgehub/table' %}
+{% resource 'knowledgehub/javascript/access_requests.js' %}
+
+{% extends "user/dashboard.html" %}
+
+{% block dashboard_activity_stream_context %}{% endblock %}
+
+{% block page_primary_action %}
+  
+{% endblock %}
+
+{% block primary_content_inner %}
+<div class="container-fluid">
+    <div class="row">
+        <div class="col-md-12">
+            <h2>{{ _('Requests for acces to data') }}</h2>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col-md-12">
+            <table id="access_requests" class="table table-hover dataTable dataTables_wrapper">
+                <thead>
+                    <tr id="access_requests-header">
+                        <th>{{ _('Requested') }}</th>
+                        <th>{{ _('Type') }}</th>
+                        <th>{{ _('Requested By') }}</th>
+                        <th>{{ _('Requested At') }}</th>
+                        <th>{{ _('Action') }}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+<div class="modal fade" id="modalGrant" tabindex="-1" role="dialog" aria-labelledby="modalDelete" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header text-center">
+                <h5 class="modal-title">{{ _('Grant Access') }}
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </h5>
+            </div>
+            <div class="modal-body mx-3">
+                <p class="text-center">
+                    {{ _('You are about to grant access to this resource. Continue?') }}
+                </p>
+            </div>
+            <div class="modal-footer d-flex justify-content-center deleteButtonsWrapper">
+                <button type="button" class="btn btn-danger btnYesClass" id="btnYes" data-dismiss="modal">{{ _('Yes') }}</button>
+                <button type="button" class="btn btn-primary btnNoClass" id="btnNo" data-dismiss="modal">{{ _('No') }}</button>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="modal fade" id="modalDecline" tabindex="-1" role="dialog" aria-labelledby="modalDelete" aria-hidden="true">
+    <div class="modal-dialog" role="document">
+        <div class="modal-content">
+            <div class="modal-header text-center">
+                <h5 class="modal-title">
+                    {{ _('Decline request') }}
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                        <span aria-hidden="true">&times;</span>
+                    </button>
+                </h5>
+            </div>
+            <div class="modal-body mx-3">
+                <p class="text-center">
+                    {{ _('Are you sure you want to decline this request?') }}
+                </p>
+            </div>
+            <div class="modal-footer d-flex justify-content-center deleteButtonsWrapper">
+                <button type="button" class="btn btn-danger btnYesClass" id="btnYes" data-dismiss="modal">{{ _('Yes') }}</button>
+                <button type="button" class="btn btn-primary btnNoClass" id="btnNo" data-dismiss="modal">{{ _('No') }}</button>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/ckanext/knowledgehub/templates/emails/access_request.txt
+++ b/ckanext/knowledgehub/templates/emails/access_request.txt
@@ -1,0 +1,15 @@
+Hello {{recipient.display_name or recipient.fullname or recipient.username}},
+
+User {{ requested_by.display_name or requested_by.fullname or requested_by.username }} has requested access to "{{ entity_title }}".
+
+Follow the link bellow to check the requests for access that you can approve:
+
+{{site_url}}/dashboard/access_requests
+
+You can view the resource here:
+
+{{site_url}}{{entity_link}}
+
+Thanks,
+
+UNHCR KnowledgeHub Team

--- a/ckanext/knowledgehub/templates/emails/access_request_granted.txt
+++ b/ckanext/knowledgehub/templates/emails/access_request_granted.txt
@@ -1,0 +1,11 @@
+Hello {{recipient.display_name or recipient.fullname or recipient.username}},
+
+Your request to access "{{ entity_title }}" was granted.
+
+You can access the resource on the URL bellow:
+
+{{site_url}}{{entity_link}}
+
+Thanks,
+
+UNHCR KnowledgeHub Team

--- a/ckanext/knowledgehub/templates/emails/access_request_granted_subject.txt
+++ b/ckanext/knowledgehub/templates/emails/access_request_granted_subject.txt
@@ -1,0 +1,1 @@
+[UNHCR KnowledgeHub] Your request for access ahs been granted

--- a/ckanext/knowledgehub/templates/emails/access_request_granted_subject.txt
+++ b/ckanext/knowledgehub/templates/emails/access_request_granted_subject.txt
@@ -1,1 +1,1 @@
-[UNHCR KnowledgeHub] Your request for access ahs been granted
+[UNHCR KnowledgeHub] Your request for access has been granted

--- a/ckanext/knowledgehub/templates/emails/access_request_subject.txt
+++ b/ckanext/knowledgehub/templates/emails/access_request_subject.txt
@@ -1,1 +1,1 @@
-[UNHCR KnowledgeHub] Access Requested to {{ entity_title }}
+[UNHCR KnowledgeHub] Access requested to {{ entity_title }}

--- a/ckanext/knowledgehub/templates/emails/access_request_subject.txt
+++ b/ckanext/knowledgehub/templates/emails/access_request_subject.txt
@@ -1,0 +1,1 @@
+[UNHCR KnowledgeHub] Access Requested to {{ entity_title }}

--- a/ckanext/knowledgehub/templates/error_document_template.html
+++ b/ckanext/knowledgehub/templates/error_document_template.html
@@ -7,7 +7,7 @@
     {% if status_code == '403' %}
         {% set entity = h.get_requested_resource_type_and_ref() %}
         {% if entity %}
-            <a href="{{ h.url_for('access.request', entity_type=entity.entity_type, entity_ref=entity.entity_ref) }}" class="btn btn-primary">
+            <a href="{{ h.url_for('access.request_access', entity_type=entity.entity_type, entity_ref=entity.entity_ref) }}" class="btn btn-primary">
                 {{ _('Request Access') }}
             </a>
         {% endif %}

--- a/ckanext/knowledgehub/templates/error_document_template.html
+++ b/ckanext/knowledgehub/templates/error_document_template.html
@@ -1,0 +1,10 @@
+{% ckan_extends %}
+
+{% block primary %}
+    {{ super() }}
+
+    {% set status_code = code[0] %}
+    {% if status_code == '403' %}
+        
+    {% endif %}
+{% endblock %}

--- a/ckanext/knowledgehub/templates/error_document_template.html
+++ b/ckanext/knowledgehub/templates/error_document_template.html
@@ -5,6 +5,11 @@
 
     {% set status_code = code[0] %}
     {% if status_code == '403' %}
-        
+        {% set entity = h.get_requested_resource_type_and_ref() %}
+        {% if entity %}
+            <a href="{{ h.url_for('access.request', entity_type=entity.entity_type, entity_ref=entity.entity_ref) }}" class="btn btn-primary">
+                {{ _('Request Access') }}
+            </a>
+        {% endif %}
     {% endif %}
 {% endblock %}

--- a/ckanext/knowledgehub/templates/error_document_template.html
+++ b/ckanext/knowledgehub/templates/error_document_template.html
@@ -2,9 +2,8 @@
 
 {% block primary %}
     {{ super() }}
-
     {% set status_code = code[0] %}
-    {% if status_code == '403' %}
+    {% if status_code == '403' or status_code == 403 %}
         {% set entity = h.get_requested_resource_type_and_ref() %}
         {% if entity %}
             <a href="{{ h.url_for('access.request_access', entity_type=entity.entity_type, entity_ref=entity.entity_ref) }}" class="btn btn-primary">

--- a/ckanext/knowledgehub/templates/user/dashboard.html
+++ b/ckanext/knowledgehub/templates/user/dashboard.html
@@ -11,6 +11,7 @@
           {{ h.build_nav_icon('dashboard.organizations', _('My Functional Units')) }}
           {{ h.build_nav_icon('dashboard.groups', _('My Joint Analysis')) }}
           {{ h.build_nav_icon('user_dashboard.user_posts', _('My Posts')) }}
+          {{ h.build_nav_icon('user_dashboard.requests_list', _('Requests for Access')) }}
         </ul>
       </header>
     {% endblock %}

--- a/ckanext/knowledgehub/views/access.py
+++ b/ckanext/knowledgehub/views/access.py
@@ -12,6 +12,8 @@ from ckan.logic import (
     get_action,
     check_access,
     NotAuthorized,
+    NotFound,
+    ValidationError,
 )
 
 
@@ -37,10 +39,35 @@ def request(entity_type, entity_ref):
         check_access('request_access', context, {})
     except NotAuthorized:
         base.abort(403, _('You do not have pemrission to request access '
-                          'on this resource.'))
+                          'for this resource.'))
         return
 
-    return base.render('access/request.html', extra_vars={})
+    extra_vars = {}
+    errors = []
+    try:
+        access_request = get_action('request_access')(context, {
+            'entity_type': entity_type,
+            'entity_ref': entity_ref,
+        })
+        extra_vars['access_request'] = access_request
+    except NotAuthorized:
+        errors.append(_('You do not have permission to request access for '
+                        'this resource.'))
+    except NotFound:
+        errors.append(_('The referenced resource was not found.'))
+    except ValidationError as e:
+        for key, value in e.error_summary.items():
+            errors.append('{} - {}'.format(key, value))
+    except Exception as e:
+        log.error('Failed to execute request_access. Error: %s', str(e))
+        log.exception(e)
+        base.abort(500, _('An unexpected error occured while processing your '
+                          'request. Error: %s' % str(e)))
+        return
+
+    extra_vars['errors'] = errors
+
+    return base.render('access/request.html', extra_vars=extra_vars)
 
 
 access.add_url_rule('/request/<entity_type>/<entity_ref>', view_func=request)

--- a/ckanext/knowledgehub/views/access.py
+++ b/ckanext/knowledgehub/views/access.py
@@ -1,0 +1,46 @@
+import logging
+import json
+
+from flask import Blueprint
+import ckan.lib.base as base
+import ckan.lib.helpers as h
+import ckan.lib.navl.dictization_functions as dict_fns
+import ckan.logic as logic
+import ckan.model as model
+from ckan.common import _, config, g, request
+from ckan.logic import (
+    get_action,
+    check_access,
+    NotAuthorized,
+)
+
+
+log = logging.getLogger(__name__)
+
+
+access = Blueprint(
+    u'access',
+    __name__,
+    url_prefix='/access',
+)
+
+
+def _get_context():
+    return dict(model=model, user=g.user,
+                auth_user_obj=g.userobj,
+                session=model.Session)
+
+
+def request(entity_type, entity_ref):
+    context = _get_context()
+    try:
+        check_access('request_access', context, {})
+    except NotAuthorized:
+        base.abort(403, _('You do not have pemrission to request access '
+                          'on this resource.'))
+        return
+
+    return base.render('access/request.html', extra_vars={})
+
+
+access.add_url_rule('/request/<entity_type>/<entity_ref>', view_func=request)

--- a/ckanext/knowledgehub/views/user.py
+++ b/ckanext/knowledgehub/views/user.py
@@ -9,6 +9,7 @@ from ckan.common import _, g, request, config
 from flask.views import MethodView
 import ckan.lib.navl.dictization_functions as dict_fns
 from ckanext.knowledgehub.helpers import check_user_profile_preferences
+import ckanext.knowledgehub.views.access as access_requests
 
 
 kwh_user = Blueprint(
@@ -479,6 +480,10 @@ kwh_user.add_url_rule(u'/profile/set_interests',
                       view_func=profile_set_interests)
 user_dashboard.add_url_rule(u'/posts', view_func=user_posts,
                             strict_slashes=False)
+
+
+# Register the rules for Access requests
+access_requests.register_url_rules(user_dashboard)
 
 
 @kwh_user.before_app_request


### PR DESCRIPTION
Implements feature for a user to request access to data that is not visible by the user.

Adds button to request access on the 403 error page - for example by clicking some post that relates to dataset/dashboard/visualization that is not available to the user, the user can click to request access to the resource.

The group admin that has access to the resource (or a sysadmin) can go to Dashboard -> Access Requests to see a list of requests made by the users. By clicking "Grant" or "Decline" can grant or decline to grant access to the user.
After granting access the user that requested it, can access the resource (dashboard, dataset or resource view)