### PR TITLE
Retrieves only active sysadmin users.

### DIFF
--- a/ckanext/knowledgehub/logic/action/create.py
+++ b/ckanext/knowledgehub/logic/action/create.py
@@ -1953,6 +1953,7 @@ def _find_sysadmins():
     '''
     q = model.Session.query(model.User)
     q = q.filter(model.user_table.c.sysadmin == True)
+    q = q.filter(model.user_table.c.state == 'active')
     sysadmins = []
     for user in q.all():
         sysadmins.append(user)


### PR DESCRIPTION
Filter out only 'active' sysadmins when sending notifications for requests for access.