### PR TITLE
fix utf-8 encoding comment on top

### DIFF
--- a/ckanext/__init__.py
+++ b/ckanext/__init__.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 """
 Copyright (c) 2018 Keitaro AB
 
@@ -15,9 +17,6 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-# encoding: utf-8
-
-# this is a namespace package
 try:
     import pkg_resources
     pkg_resources.declare_namespace(__name__)

--- a/ckanext/knowledgehub/backend/__init__.py
+++ b/ckanext/knowledgehub/backend/__init__.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """
 Copyright (c) 2018 Keitaro AB
 
@@ -15,7 +17,6 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-# -*- coding: utf-8 -*-
 class Backend:
 
     def configure(self, config):

--- a/ckanext/knowledgehub/backend/factory.py
+++ b/ckanext/knowledgehub/backend/factory.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """
 Copyright (c) 2018 Keitaro AB
 
@@ -15,7 +17,6 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-# -*- coding: utf-8 -*-
 import logging
 
 import ckan.plugins.toolkit as toolkit

--- a/ckanext/knowledgehub/cli/__init__.py
+++ b/ckanext/knowledgehub/cli/__init__.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 """
 Copyright (c) 2018 Keitaro AB
 
@@ -14,8 +16,6 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
-
-# encoding: utf-8
 
 import os
 

--- a/ckanext/knowledgehub/cli/cli.py
+++ b/ckanext/knowledgehub/cli/cli.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 """
 Copyright (c) 2018 Keitaro AB
 
@@ -14,8 +16,6 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
-
-# encoding: utf-8
 
 import logging
 

--- a/ckanext/knowledgehub/cli/db.py
+++ b/ckanext/knowledgehub/cli/db.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 """
 Copyright (c) 2018 Keitaro AB
 
@@ -14,8 +16,6 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
-
-# encoding: utf-8
 
 import click
 import logging

--- a/ckanext/knowledgehub/cli/predictive_search.py
+++ b/ckanext/knowledgehub/cli/predictive_search.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 """
 Copyright (c) 2018 Keitaro AB
 
@@ -14,8 +16,6 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
-
-# encoding: utf-8
 
 import click
 import logging

--- a/ckanext/knowledgehub/controllers/group.py
+++ b/ckanext/knowledgehub/controllers/group.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 """
 Copyright (c) 2018 Keitaro AB
 
@@ -14,8 +16,6 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
-
-# encoding: utf-8
 
 import logging
 import datetime

--- a/ckanext/knowledgehub/controllers/organization.py
+++ b/ckanext/knowledgehub/controllers/organization.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 """
 Copyright (c) 2018 Keitaro AB
 
@@ -14,8 +16,6 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
-
-# encoding: utf-8
 
 import logging
 from urllib import urlencode

--- a/ckanext/knowledgehub/lib/quality.py
+++ b/ckanext/knowledgehub/lib/quality.py
@@ -1,3 +1,5 @@
+# -*- coding: UTF-8 -*-
+
 """
 Copyright (c) 2018 Keitaro AB
 
@@ -14,8 +16,6 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
-
-# -*- coding: UTF-8 -*-
 
 import ckan.plugins.toolkit as toolkit
 import ckan.lib.uploader as uploader

--- a/ckanext/knowledgehub/lib/writer.py
+++ b/ckanext/knowledgehub/lib/writer.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """
 Copyright (c) 2018 Keitaro AB
 
@@ -15,7 +17,6 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-# -*- coding: utf-8 -*-
 import logging
 import csv
 import cStringIO

--- a/ckanext/knowledgehub/model/theme.py
+++ b/ckanext/knowledgehub/model/theme.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 """
 Copyright (c) 2018 Keitaro AB
 
@@ -15,7 +17,6 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-# encoding: utf-8
 import datetime
 
 from sqlalchemy import (

--- a/ckanext/knowledgehub/model/user_profile.py
+++ b/ckanext/knowledgehub/model/user_profile.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 """
 Copyright (c) 2018 Keitaro AB
 
@@ -15,7 +17,6 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-# encoding: utf-8
 import datetime
 
 from sqlalchemy import (

--- a/ckanext/knowledgehub/views/dashboard.py
+++ b/ckanext/knowledgehub/views/dashboard.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 """
 Copyright (c) 2018 Keitaro AB
 
@@ -15,7 +17,6 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-# encoding: utf-8
 import logging
 import json
 

--- a/ckanext/knowledgehub/views/kwh_dataset.py
+++ b/ckanext/knowledgehub/views/kwh_dataset.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 """
 Copyright (c) 2018 Keitaro AB
 
@@ -15,7 +17,6 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-# encoding: utf-8
 import logging
 import datetime
 from werkzeug.datastructures import FileStorage as FlaskFileStorage

--- a/ckanext/knowledgehub/views/newsfeed.py
+++ b/ckanext/knowledgehub/views/newsfeed.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 """
 Copyright (c) 2018 Keitaro AB
 
@@ -15,7 +17,6 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-# encoding: utf-8
 import logging
 
 from flask import Blueprint

--- a/ckanext/knowledgehub/views/theme.py
+++ b/ckanext/knowledgehub/views/theme.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 """
 Copyright (c) 2018 Keitaro AB
 
@@ -15,7 +17,6 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-# encoding: utf-8
 import logging
 
 from flask import Blueprint

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 """
 Copyright (c) 2018 Keitaro AB
 
@@ -15,7 +17,6 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <https://www.gnu.org/licenses/>.
 """
 
-# -*- coding: utf-8 -*-
 from setuptools import setup, find_packages  # Always prefer setuptools over distutils
 from codecs import open  # To use a consistent encoding
 from os import path


### PR DESCRIPTION
@duskobogdanovski I moved the utf-8 encoding comment to the top of .py files. Please review the changes, and if everything is OK merge the PR.